### PR TITLE
added Geometry.add_physical_line instance method

### DIFF
--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -123,6 +123,12 @@ class Geometry(object):
             )
         return name
 
+    def add_physical_line(self, line, label):
+        self._GMSH_CODE.append(
+            'Physical Line("%s") = %s;' % (label, line)
+            )
+        return
+
     def add_plane_surface(self, line_loop):
         self._SURFACE_ID += 1
         sname = 'surf%d' % self._SURFACE_ID


### PR DESCRIPTION
By analogy with `add_physical_surface` and `add_physical_volume`, the `Physical Line` exists in Gmsh to label:

- boundaries in  two-dimensional meshes and
- subdomains in one-dimensional meshes.