### PR TITLE
coding: utf8 -> utf-8

### DIFF
--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 #
 '''
 This class provides a Python interface for the Gmsh scripting language.  It

--- a/pygmsh/helper.py
+++ b/pygmsh/helper.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 #
 import numpy
 


### PR DESCRIPTION
Correct name of coding is `utf-8`, with hyphen; see [PEP 263](https://www.python.org/dev/peps/pep-0263) or output of `list-coding-systems` in GNU Emacs.   Mule complains without the hyphen.