### PR TITLE
added add_physical_point instance method to Geometry

### DIFF
--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -60,6 +60,12 @@ class Geometry(object):
             )
         return name
 
+    def add_physical_point(self, point, label):
+        self._GMSH_CODE.append(
+            'Physical Point("%s") = %s;' % (label, point)
+            )
+        return
+
     def add_line(self, p0, p1):
         self._LINE_ID += 1
         name = 'l%d' % self._LINE_ID


### PR DESCRIPTION
As discussed following #17, which added `add_physical_line`, here is the missing zero-dimensional analogue.

This does not include the handling of expression-lists discussed in #19.