### PR TITLE
Docs fixes,

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,9 +12,11 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-import shlex
+
+ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
+
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -113,6 +115,13 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'default'
+if not ON_RTD:
+    try:
+        import sphinx_rtd_theme
+        html_theme = "sphinx_rtd_theme"
+        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+    except ImportError:
+        pass
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -141,7 +150,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,8 +11,10 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   self
+
 :mod:`pygmsh.geometry`
-=====================
+======================
 
 .. automodule:: pygmsh.geometry
     :members:


### PR DESCRIPTION
Build with readthedocs theme if installed locally.

include self in toc (keyword) to populate the sidebar on RTD.

--- 

Not, we avoid to set the Theme as the readthedocs one when not on readthedocs, to avoid screwing up readthedocs that can update their theme, and thus build with the new version. 