### PR TITLE
skip Lloyd smoothing in one-dimensional cases

### DIFF
--- a/pygmsh/helper.py
+++ b/pygmsh/helper.py
@@ -79,7 +79,7 @@ def generate_mesh(
     X, cells, pt_data, cell_data, field_data = meshio.read(outname)
 
     # Lloyd smoothing
-    if (abs(X[:, 2]) > 1.0e-15).any():
+    if (abs(X[:, 2]) > 1.0e-15).any() or (abs(X[:, 1]) <= 1.0e-15).all():
         print('Not performing Lloyd smoothing (only works for 2D meshes).')
         return X, cells, pt_data, cell_data, field_data
     print('Lloyd smoothing...')


### PR DESCRIPTION
Trying to run `generate_mesh` on a one-dimensional geometry raises a `KeyError` because in one-dimension `cell_data` won't have a 'triangle' key.  Lloyd smoothing is unnecessary in this case anyway, so just return the unsmoothed mesh.

One could test `'triangle' in cell_data` but the PR is consistent with the current floating-point test for three-dimensionality.