### PR TITLE
Extrude lateral surfaces

### DIFF
--- a/pygmsh/compound_surface.py
+++ b/pygmsh/compound_surface.py
@@ -6,7 +6,7 @@ from .surface_base import SurfaceBase
 class CompoundSurface(SurfaceBase):
     def __init__(self, surfaces):
         super(CompoundSurface, self).__init__()
-        self.num_edges = sum(len(s) for s in surfaces)
+        self.num_edges = sum(s.num_edges for s in surfaces)
 
         self.surfaces = surfaces
 

--- a/pygmsh/compound_surface.py
+++ b/pygmsh/compound_surface.py
@@ -6,6 +6,7 @@ from .surface_base import SurfaceBase
 class CompoundSurface(SurfaceBase):
     def __init__(self, surfaces):
         super(CompoundSurface, self).__init__()
+        self.num_edges = sum(len(s) for s in surfaces)
 
         self.surfaces = surfaces
 

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -358,7 +358,8 @@ class Geometry(object):
             # each lateral surface has 4 edges: the one from input_entity,
             # the one from top, and the two lines (or splines) connecting their
             # extreme points.
-            lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) for i in range(input_entity.num_edges)]
+            lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) \
+              for i in range(input_entity.num_edges)]
 
         return top, extruded, lat
 

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -724,7 +724,7 @@ class Geometry(object):
             for k, p in enumerate(previous):
                 # ts1[] = Extrude {{0,0,1}, {0,0,0}, 2*Pi/3}{Line{tc1};};
                 # ...
-                top, surf = self.extrude(
+                top, surf, _ = self.extrude(
                     p,
                     rotation_axis=rot_axis,
                     point_on_axis=point_on_rot_axis,
@@ -781,12 +781,13 @@ class Geometry(object):
         # Extrude() macro returns an array; the first [0] entry in the array is
         # the entity that has been extruded at the far end. This can be used
         # for the following Extrude() step.  The second [1] entry of the array
-        # is the surface that was created by the extrusion.
+        # is the surface that was created by the extrusion. The third [2-end] is
+        # a list of all the planes of the lateral surface.
         previous = c.plane_surface
         all_volumes = []
         num_steps = 3
         for _ in range(num_steps):
-            top, vol = self.extrude(
+            top, vol, _ = self.extrude(
                 previous,
                 rotation_axis=rot_axis,
                 point_on_axis=point_on_rot_axis,
@@ -866,7 +867,7 @@ class Geometry(object):
             self.add_comment('Step {}'.format(i+1))
             for k, p in enumerate(previous):
                 # ts1[] = Extrude {{0,0,1}, {0,0,0}, 2*Pi/3}{Line{tc1};};
-                top, surf = self.extrude(
+                top, surf, _ = self.extrude(
                         p,
                         rotation_axis=rot_axis,
                         point_on_axis=point_on_rot_axis,
@@ -912,7 +913,7 @@ class Geometry(object):
                 )
 
         # Now Extrude the ring surface.
-        _, vol = self.extrude(
+        _, vol, _ = self.extrude(
                 circ.plane_surface,
                 translation_axis=numpy.dot(R, [length, 0, 0])
                 )

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -342,7 +342,8 @@ class Geometry(object):
 
         if isinstance(input_entity, LineBase):
             top = LineBase(top)
-            extruded = SurfaceBase(extruded)
+            # A surface extruded from a single line has always 4 edges
+            extruded = SurfaceBase(4, extruded)
         elif isinstance(input_entity, SurfaceBase):
             top = SurfaceBase(input_entity.num_edges, top)
             extruded = VolumeBase(extruded)

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -343,9 +343,9 @@ class Geometry(object):
         if isinstance(input_entity, LineBase):
             top = LineBase(top)
             # A surface extruded from a single line has always 4 edges
-            extruded = SurfaceBase(4, extruded)
+            extruded = SurfaceBase(extruded, 4)
         elif isinstance(input_entity, SurfaceBase):
-            top = SurfaceBase(input_entity.num_edges, top)
+            top = SurfaceBase(top, input_entity.num_edges)
             extruded = VolumeBase(extruded)
         else:
             top = Dummy(top)
@@ -359,7 +359,7 @@ class Geometry(object):
             # each lateral surface has 4 edges: the one from input_entity,
             # the one from top, and the two lines (or splines) connecting their
             # extreme points.
-            lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) \
+            lat = [SurfaceBase('{}[{}]'.format(name, i+2), 4) \
               for i in range(input_entity.num_edges)]
 
         return top, extruded, lat

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -351,7 +351,13 @@ class Geometry(object):
             extruded = Dummy(extruded)
 
         lat = []
+        # lateral surfaces can be deduced only if we start from a SurfaceBase
         if isinstance(input_entity, SurfaceBase):
+            # out[0]` is the surface, out[1] the top, and everything after that
+            # the sides, cf.<http://gmsh.info/doc/texinfo/gmsh.html#Extrusions>.
+            # each lateral surface has 4 edges: the one from input_entity,
+            # the one from top, and the two lines (or splines) connecting their
+            # extreme points.
             lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) for i in range(input_entity.num_edges())]
 
         return top, extruded, lat

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -276,7 +276,6 @@ class Geometry(object):
             rotation_axis=None,
             point_on_axis=None,
             angle=None,
-            get_lateral=False
             ):
         '''Extrusion (translation + rotation) of any entity along a given
         translation_axis, around a given rotation_axis, about a given angle. If
@@ -355,10 +354,7 @@ class Geometry(object):
         if isinstance(input_entity, SurfaceBase):
             lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) for i in range(input_entity.num_edges())]
 
-        if get_lateral:
-            return top, extruded, lat
-        else:
-            return top, extruded
+        return top, extruded, lat
 
     def add_boundary_layer(
             self,

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -344,7 +344,7 @@ class Geometry(object):
             top = LineBase(top)
             extruded = SurfaceBase(extruded)
         elif isinstance(input_entity, SurfaceBase):
-            top = SurfaceBase(input_entity.num_edges(), top)
+            top = SurfaceBase(input_entity.num_edges, top)
             extruded = VolumeBase(extruded)
         else:
             top = Dummy(top)
@@ -358,7 +358,7 @@ class Geometry(object):
             # each lateral surface has 4 edges: the one from input_entity,
             # the one from top, and the two lines (or splines) connecting their
             # extreme points.
-            lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) for i in range(input_entity.num_edges())]
+            lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) for i in range(input_entity.num_edges)]
 
         return top, extruded, lat
 

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -345,7 +345,7 @@ class Geometry(object):
             top = LineBase(top)
             extruded = SurfaceBase(extruded)
         elif isinstance(input_entity, SurfaceBase):
-            top = SurfaceBase(len(input_entity), top)
+            top = SurfaceBase(input_entity.num_edges(), top)
             extruded = VolumeBase(extruded)
         else:
             top = Dummy(top)
@@ -353,7 +353,7 @@ class Geometry(object):
 
         lat = []
         if isinstance(input_entity, SurfaceBase):
-            lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) for i in range(len(input_entity))]
+            lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) for i in range(input_entity.num_edges())]
 
         if get_lateral:
             return top, extruded, lat

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -275,7 +275,8 @@ class Geometry(object):
             translation_axis=None,
             rotation_axis=None,
             point_on_axis=None,
-            angle=None
+            angle=None,
+            get_lateral=False
             ):
         '''Extrusion (translation + rotation) of any entity along a given
         translation_axis, around a given rotation_axis, about a given angle. If
@@ -344,13 +345,20 @@ class Geometry(object):
             top = LineBase(top)
             extruded = SurfaceBase(extruded)
         elif isinstance(input_entity, SurfaceBase):
-            top = SurfaceBase(top)
+            top = SurfaceBase(len(input_entity), top)
             extruded = VolumeBase(extruded)
         else:
             top = Dummy(top)
             extruded = Dummy(extruded)
 
-        return top, extruded
+        lat = []
+        if isinstance(input_entity, SurfaceBase):
+            lat = [SurfaceBase(4, '{}[{}]'.format(name, i+2)) for i in range(len(input_entity))]
+
+        if get_lateral:
+            return top, extruded, lat
+        else:
+            return top, extruded
 
     def add_boundary_layer(
             self,

--- a/pygmsh/line_loop.py
+++ b/pygmsh/line_loop.py
@@ -17,3 +17,6 @@ class LineLoop(object):
                 self.id, ', '.join([l.id for l in lines])
             )])
         return
+
+    def __len__(self):
+        return len(self.lines)

--- a/pygmsh/plane_surface.py
+++ b/pygmsh/plane_surface.py
@@ -27,5 +27,5 @@ class PlaneSurface(SurfaceBase):
             'Plane Surface({}) = {{{}}};'.format(
                 self.id, ','.join([ll.id for ll in line_loops])
             )])
-        self.num_edges = len(self.line_loop) + sum(len(h) for h in self.holes)
+        self._num_edges = len(self.line_loop) + sum(len(h) for h in self.holes)
         return

--- a/pygmsh/plane_surface.py
+++ b/pygmsh/plane_surface.py
@@ -27,5 +27,5 @@ class PlaneSurface(SurfaceBase):
             'Plane Surface({}) = {{{}}};'.format(
                 self.id, ','.join([ll.id for ll in line_loops])
             )])
-        self._num_edges = len(self.line_loop) + sum(len(h) for h in self.holes)
+        self.num_edges = len(self.line_loop) + sum(len(h) for h in self.holes)
         return

--- a/pygmsh/plane_surface.py
+++ b/pygmsh/plane_surface.py
@@ -27,4 +27,5 @@ class PlaneSurface(SurfaceBase):
             'Plane Surface({}) = {{{}}};'.format(
                 self.id, ','.join([ll.id for ll in line_loops])
             )])
+        self.num_edges = len(self.line_loop) + sum(len(h) for h in self.holes)
         return

--- a/pygmsh/ruled_surface.py
+++ b/pygmsh/ruled_surface.py
@@ -5,6 +5,7 @@ from .line_loop import LineLoop
 
 class RuledSurface(object):
     _ID = 0
+    num_edges = 0
 
     def __init__(self, line_loop):
         assert isinstance(line_loop, LineLoop)
@@ -18,4 +19,5 @@ class RuledSurface(object):
             '{} = news;'.format(self.id),
             'Ruled Surface({}) = {{{}}};'.format(self.id, self.line_loop.id)
             ])
+        self.num_edges = len(line_loop)
         return

--- a/pygmsh/surface_base.py
+++ b/pygmsh/surface_base.py
@@ -6,7 +6,8 @@ class SurfaceBase(object):
     _ID = 0
     num_edges = 0
 
-    def __init__(self, num_edges=0, id0=None):
+    def __init__(self, id0=None, num_edges=0):
+        isinstance(id0, str)
         if id0:
             self.id = id0
         else:

--- a/pygmsh/surface_base.py
+++ b/pygmsh/surface_base.py
@@ -4,11 +4,16 @@
 
 class SurfaceBase(object):
     _ID = 0
+    num_edges = 0
 
-    def __init__(self, id0=None):
+    def __init__(self, num_edges=0, id0=None):
         if id0:
             self.id = id0
         else:
             self.id = 's{}'.format(SurfaceBase._ID)
             SurfaceBase._ID += 1
+        self.num_edges = num_edges
         return
+
+    def __len__(self):
+        return self.num_edges

--- a/pygmsh/surface_base.py
+++ b/pygmsh/surface_base.py
@@ -4,7 +4,7 @@
 
 class SurfaceBase(object):
     _ID = 0
-    num_edges = 0
+    _num_edges = 0
 
     def __init__(self, num_edges=0, id0=None):
         if id0:
@@ -12,8 +12,8 @@ class SurfaceBase(object):
         else:
             self.id = 's{}'.format(SurfaceBase._ID)
             SurfaceBase._ID += 1
-        self.num_edges = num_edges
+        self._num_edges = num_edges
         return
 
-    def __len__(self):
-        return self.num_edges
+    def num_edges(self):
+        return self._num_edges

--- a/pygmsh/surface_base.py
+++ b/pygmsh/surface_base.py
@@ -4,7 +4,7 @@
 
 class SurfaceBase(object):
     _ID = 0
-    _num_edges = 0
+    num_edges = 0
 
     def __init__(self, num_edges=0, id0=None):
         if id0:
@@ -12,8 +12,5 @@ class SurfaceBase(object):
         else:
             self.id = 's{}'.format(SurfaceBase._ID)
             SurfaceBase._ID += 1
-        self._num_edges = num_edges
+        self.num_edges = num_edges
         return
-
-    def num_edges(self):
-        return self._num_edges


### PR DESCRIPTION
Optionally return lateral surfaces when extruding.
This is useful for adding physical surfaces to the lateral faces that generally come up as walls in CFD simulations in extruded geometries.