### PR TITLE
close msh file handle before 'remove' operation

### DIFF
--- a/pygmsh/helper.py
+++ b/pygmsh/helper.py
@@ -96,6 +96,7 @@ def generate_mesh(
     os.close(handle)
 
     handle, msh_filename = tempfile.mkstemp(suffix='.msh')
+    os.close(handle)
 
     gmsh_executable = _get_gmsh_exe()
 


### PR DESCRIPTION
Current clean up operation `os.remove(msh_filename)` will cause a permission denied error, since msh file handle is still being hold by the system.
Removing geo file won't meet this problem because the handle has already been closed in line 96.