### PR TITLE
Add support for gmsh 3 factories

### DIFF
--- a/pygmsh/__about__.py
+++ b/pygmsh/__about__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 __author__ = u'Nico Schlömer'
 __author_email__ = 'nico.schloemer@gmail.com'
 __website__ = 'https://github.com/nschloe/pygmsh'

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -18,7 +18,7 @@ from .compound_surface import CompoundSurface
 from .compound_volume import CompoundVolume
 from .dummy import Dummy
 from .ellipse_arc import EllipseArc
-from .helper import _is_string
+from .helper import _is_string, _get_gmsh_major_version
 from .line import Line
 from .line_base import LineBase
 from .line_loop import LineLoop
@@ -46,6 +46,7 @@ class Geometry(object):
         self._EXTRUDE_ID = 0
         self._ARRAY_ID = 0
         self._FIELD_ID = 0
+        self._GMSH_MAJOR = _get_gmsh_major_version()
         self._FACTORY_TYPE = 'Built-in'
         self._TAKEN_PHYSICALGROUP_IDS = []
         self._GMSH_CODE = [

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -6,8 +6,8 @@ at working around some of Gmsh's inconveniences (e.g., having to manually
 assign an ID for every entity created) and providing access to Python's
 features.
 '''
-import numpy
 import re
+import numpy
 
 from .__about__ import __version__
 
@@ -59,7 +59,14 @@ class Geometry(object):
         '''
         return '\n'.join(self._GMSH_CODE)
 
+    def get_gmsh_major(self):
+        '''Return the major version of the gmsh executable.
+        '''
+        return self._GMSH_MAJOR
+
     def set_factory(self, factory_type):
+        '''Set the geometry factory between Built-in and openCASCADE
+        '''
         assert self._GMSH_MAJOR == 3, \
             'Gmsh 2 does not support factories.'
 

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -7,6 +7,7 @@ assign an ID for every entity created) and providing access to Python's
 features.
 '''
 import numpy
+import re
 
 from .__about__ import __version__
 
@@ -145,7 +146,11 @@ class Geometry(object):
 
     def add_ruled_surface(self, *args, **kwargs):
         p = RuledSurface(*args, **kwargs)
-        self._GMSH_CODE.append(p.code)
+        if self._FACTORY_TYPE == 'Built-in':
+            self._GMSH_CODE.append(p.code)
+        else:
+            # OpenCASCADE knows only of Surfaces without Ruled
+            self._GMSH_CODE.append(re.sub('Ruled Surface', 'Surface', p.code))
         return p
 
     def add_surface_loop(self, *args, **kwargs):

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -60,8 +60,12 @@ class Geometry(object):
         return '\n'.join(self._GMSH_CODE)
 
     def set_factory(self, factory_type):
+        assert self._GMSH_MAJOR == 3, \
+            'Gmsh 2 does not support factories.'
+
         assert factory_type == 'OpenCASCADE' or factory_type == 'Built-in', \
             'Factory type not recognized.'
+
         # the factory should always be set as first thing in the geo file
         if len(self._GMSH_CODE) == 1:
             # no code yet

--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -45,6 +45,7 @@ class Geometry(object):
         self._EXTRUDE_ID = 0
         self._ARRAY_ID = 0
         self._FIELD_ID = 0
+        self._FACTORY_TYPE = 'Built-in'
         self._TAKEN_PHYSICALGROUP_IDS = []
         self._GMSH_CODE = [
                 '// This code was created by PyGmsh v{}.'.format(__version__)
@@ -55,6 +56,24 @@ class Geometry(object):
         '''Returns properly formatted Gmsh code.
         '''
         return '\n'.join(self._GMSH_CODE)
+
+    def set_factory(self, factory_type):
+        assert factory_type == 'OpenCASCADE' or factory_type == 'Built-in', \
+            'Factory type not recognized.'
+        # the factory should always be set as first thing in the geo file
+        if len(self._GMSH_CODE) == 1:
+            # no code yet
+            self._FACTORY_TYPE = factory_type
+            self._GMSH_CODE.append('SetFactory("{}");'.format(factory_type))
+        else:
+            if factory_type != self._FACTORY_TYPE:
+                if self._GMSH_CODE[1][:10] == 'SetFactory':
+                    # replace the current factory statement
+                    self._GMSH_CODE[1] = 'SetFactory("{}");'.format(factory_type)
+                else:
+                    # insert a new statement for the Factory
+                    self._GMSH_CODE.insert(1, 'SetFactory("{}");'.format(factory_type))
+                self._FACTORY_TYPE = factory_type
 
     # All of the add_* method below could be replaced by
     #

--- a/pygmsh/helper.py
+++ b/pygmsh/helper.py
@@ -105,7 +105,7 @@ def generate_mesh(
         '-{}'.format(dim), '-bin', geo_filename, '-o', msh_filename
         ]
 
-    gmsh_major_version = geo_object._GMSH_MAJOR
+    gmsh_major_version = geo_object.get_gmsh_major()
     if gmsh_major_version < 3 and optimize:
         cmd += ['-optimize']
 

--- a/pygmsh/helper.py
+++ b/pygmsh/helper.py
@@ -105,7 +105,7 @@ def generate_mesh(
         '-{}'.format(dim), '-bin', geo_filename, '-o', msh_filename
         ]
 
-    gmsh_major_version = _get_gmsh_major_version()
+    gmsh_major_version = geo_object._GMSH_MAJOR
     if gmsh_major_version < 3 and optimize:
         cmd += ['-optimize']
 

--- a/test/examples/__init__.py
+++ b/test/examples/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
   'circle',
   'cube',
   'ellipsoid',
+  'factory',
   'pacman',
   'pipes',
   'rectangle_with_hole',

--- a/test/examples/factory.py
+++ b/test/examples/factory.py
@@ -8,7 +8,7 @@ import pygmsh as pg
 def generate():
     geom = pg.Geometry()
 
-    if geom._GMSH_MAJOR == 3:
+    if geom.get_gmsh_major() == 3:
         # factories are supported only in gmsh 3
         geom.set_factory("OpenCASCADE")
         geom.add_box(0, 1, 0, 1, 0, 1, 1.0)
@@ -20,8 +20,8 @@ def generate():
 
 if __name__ == '__main__':
     import meshio
-    geom, _ = generate()
+    geometry, _ = generate()
     with open('factory.geo', 'w') as f:
-        f.write(geom.get_code())
-    out = pg.generate_mesh(geom)
+        f.write(geometry.get_code())
+    out = pg.generate_mesh(geometry)
     meshio.write('factory.vtu', *out)

--- a/test/examples/factory.py
+++ b/test/examples/factory.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+'''Check factory setup.
+'''
+import pygmsh as pg
+
+
+def generate():
+    geom = pg.Geometry()
+    geom.set_factory("OpenCASCADE")
+    geom.add_box(0, 1, 0, 1, 0, 1, 1.0)
+    geom.set_factory("Built-in")
+    geom.set_factory("OpenCASCADE")
+    return geom, 1.0
+
+
+if __name__ == '__main__':
+    import meshio
+    geom, _ = generate()
+    with open('factory.geo', 'w') as f:
+        f.write(geom.get_code())
+    out = pg.generate_mesh(geom)
+    meshio.write('factory.vtu', *out)

--- a/test/examples/factory.py
+++ b/test/examples/factory.py
@@ -7,12 +7,16 @@ import pygmsh as pg
 
 def generate():
     geom = pg.Geometry()
-    geom.set_factory("OpenCASCADE")
-    geom.add_box(0, 1, 0, 1, 0, 1, 1.0)
-    geom.set_factory("Built-in")
-    geom.set_factory("OpenCASCADE")
-    return geom, 1.0
 
+    if geom._GMSH_MAJOR == 3:
+        # factories are supported only in gmsh 3
+        geom.set_factory("OpenCASCADE")
+        geom.add_box(0, 1, 0, 1, 0, 1, 1.0)
+        geom.set_factory("Built-in")
+        geom.set_factory("OpenCASCADE")
+    else:
+        geom.add_box(0, 1, 0, 1, 0, 1, 1.0)
+    return geom, 1.0
 
 if __name__ == '__main__':
     import meshio


### PR DESCRIPTION
The new functionality cannot be tested with the current ci since there is no gmsh-3, but it should gracefully revert to the previous behavior when using gmsh-2.
All tests are running for me with python 2.7.13 and gmsh 3.0.2