### PR TITLE
Assert rotation axis unitary

### DIFF
--- a/pygmsh/helper.py
+++ b/pygmsh/helper.py
@@ -19,6 +19,9 @@ def rotation_matrix(u, theta):
     :param u: rotation vector
     :param theta: rotation angle
     '''
+    assert numpy.isclose(numpy.inner(u, u), 1.), \
+        'the rotation axis must be unitary'
+
     # Cross-product matrix.
     cpm = numpy.array([
         [0.0, -u[2], u[1]],

--- a/test/examples/pipes.py
+++ b/test/examples/pipes.py
@@ -10,7 +10,8 @@ def generate():
     '''
     geom = pg.Geometry()
 
-    R = pg.rotation_matrix([1, 1, 0], np.pi/6.0)
+    sqrt2on2 = 0.5*np.sqrt(2.)
+    R = pg.rotation_matrix([sqrt2on2, sqrt2on2, 0], np.pi/6.0)
     geom.add_pipe(
             inner_radius=0.3,
             outer_radius=0.4,
@@ -33,7 +34,7 @@ def generate():
             variant='circle_extrusion'
             )
 
-    return geom, 0.5317080205627609
+    return geom, 0.43988203517453256
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
as reported by the wiki page mentioned in the comment, the rotation axis must be unitary, otherwise scales are not preserved.
I don't know if this was a "feature", but in that case it should be mentioned in the method description.