### PR TITLE
Spline (not Bspline) for OpenCascade

### DIFF
--- a/pygmsh/geometry.py
+++ b/pygmsh/geometry.py
@@ -12,6 +12,7 @@ import numpy
 from .__about__ import __version__
 
 from .bspline import Bspline
+from .spline import Spline
 from .circle_arc import CircleArc
 from .compound_line import CompoundLine
 from .compound_surface import CompoundSurface
@@ -112,6 +113,11 @@ class Geometry(object):
         self._GMSH_CODE.append(p.code)
         return p
 
+    def add_spline(self, *args, **kwargs):
+        p = Spline(*args, **kwargs)
+        self._GMSH_CODE.append(p.code)
+        return p
+    
     def add_circle_arc(self, *args, **kwargs):
         p = CircleArc(*args, **kwargs)
         self._GMSH_CODE.append(p.code)

--- a/pygmsh/spline.py
+++ b/pygmsh/spline.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+from .line_base import LineBase
+from .point import Point
+
+
+class Spline(LineBase):
+    def __init__(self, control_points):
+        super(Spline, self).__init__()
+
+        for c in control_points:
+            assert isinstance(c, Point)
+        assert len(control_points) > 2
+
+        self.control_points = control_points
+
+        self.code = '\n'.join([
+            '{} = newl;'.format(self.id),
+            'Spline({}) = {{{}}};'.format(
+                self.id, ', '.join([c.id for c in self.control_points])
+            )])
+        return


### PR DESCRIPTION
For OpenCascade, one has to use Spline instead of BSpline.