### PR TITLE
Fixes the documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ pytest
 
 ### Building Documentation
 
-Docs are build using [Sphinx](http://www.sphinx-doc.org/en/stable/).
+Docs are built using [Sphinx](http://www.sphinx-doc.org/en/stable/).
 
 To build run
 ```

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ To run the pygmsh unit tests, check out this repository and type
 pytest
 ```
 
+### Building Documentation
+
+Docs are build using [Sphinx](http://www.sphinx-doc.org/en/stable/).
+
+To build run
+```
+sphinx-build -b html doc doc/_build
+```
+
 ### Distribution
 
 To create a new release

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,19 +13,19 @@ Contents:
 
    self
 
-:mod:`pygmsh.geometry`
-======================
+:mod:`pygmsh.built_in.geometry`
+===============================
 
-.. automodule:: pygmsh.geometry
+.. automodule:: pygmsh.built_in.geometry
     :members:
     :undoc-members:
     :show-inheritance:
 
 
-:mod:`pygmsh.helper`
+:mod:`pygmsh.helpers`
 =====================
 
-.. automodule:: pygmsh.helper
+.. automodule:: pygmsh.helpers
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Fixes the documentation page. It appears to have broken when the main module was migrated to `built_in`.