### PR TITLE
not prematurely closing extrusion_string if rotation_axis is None #128

### DIFF
--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -315,7 +315,7 @@ class Geometry(object):
             else:
                 # Only translation
                 extrusion_string = \
-                    '{}[] = Extrude{{{}}}{{{};}};'.format(
+                    '{}[] = Extrude {{{}}} {{{};'.format(
                         name,
                         ','.join(repr(x) for x in translation_axis),
                         entity.id


### PR DESCRIPTION
For all cases in which `translation_axis is not None`, there is a common closure with `'};'`, just before `extrusion_string` is appended to the Gmsh code.
