### PR TITLE
Splines (not BSplines) for built_in

### DIFF
--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -81,11 +81,6 @@ class Geometry(object):
         self._GMSH_CODE.append(p.code)
         return p
 
-    def add_spline(self, *args, **kwargs):
-        p = Spline(*args, **kwargs)
-        self._GMSH_CODE.append(p.code)
-        return p
-
     def add_circle_arc(self, *args, **kwargs):
         p = CircleArc(*args, **kwargs)
         self._GMSH_CODE.append(p.code)
@@ -128,6 +123,11 @@ class Geometry(object):
 
     def add_point(self, *args, **kwargs):
         p = Point(*args, **kwargs)
+        self._GMSH_CODE.append(p.code)
+        return p
+
+    def add_spline(self, *args, **kwargs):
+        p = Spline(*args, **kwargs)
         self._GMSH_CODE.append(p.code)
         return p
 

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -32,6 +32,7 @@ from .line_base import LineBase
 from .line_loop import LineLoop
 from .plane_surface import PlaneSurface
 from .point import Point
+from .spline import Spline
 from .surface import Surface
 from .surface_base import SurfaceBase
 from .surface_loop import SurfaceLoop
@@ -77,6 +78,11 @@ class Geometry(object):
 
     def add_bspline(self, *args, **kwargs):
         p = Bspline(*args, **kwargs)
+        self._GMSH_CODE.append(p.code)
+        return p
+
+    def add_spline(self, *args, **kwargs):
+        p = Spline(*args, **kwargs)
         self._GMSH_CODE.append(p.code)
         return p
 

--- a/pygmsh/built_in/spline.py
+++ b/pygmsh/built_in/spline.py
@@ -16,7 +16,7 @@ class Spline(LineBase):
 
         self.code = '\n'.join([
             '{} = newl;'.format(self.id),
-            'BSpline({}) = {{{}}};'.format(
+            'Spline({}) = {{{}}};'.format(
                 self.id, ', '.join([c.id for c in self.points])
             )])
         return

--- a/pygmsh/built_in/spline.py
+++ b/pygmsh/built_in/spline.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+from .line_base import LineBase
+from .point import Point
+
+
+class Spline(LineBase):
+    def __init__(self, points):
+        super(Spline, self).__init__()
+
+        for c in points:
+            assert isinstance(c, Point)
+        assert len(points) > 3
+
+        self.points = points
+
+        self.code = '\n'.join([
+            '{} = newl;'.format(self.id),
+            'BSpline({}) = {{{}}};'.format(
+                self.id, ', '.join([c.id for c in self.points])
+            )])
+        return

--- a/test/test_splines.py
+++ b/test/test_splines.py
@@ -1,0 +1,34 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+import pygmsh
+
+from helpers import compute_volume
+
+
+def test():
+    geom = pygmsh.built_in.Geometry()
+
+    lcar = 0.1
+    p1 = geom.add_point([0.0, 0.0, 0.0], lcar)
+    p2 = geom.add_point([1.0, 0.0, 0.0], lcar)
+    p3 = geom.add_point([1.0, 0.5, 0.0], lcar)
+    p4 = geom.add_point([1.0, 1.0, 0.0], lcar)
+    s1 = geom.add_spline([p1, p2, p3, p4])
+
+    p2 = geom.add_point([0.0, 1.0, 0.0], lcar)
+    p3 = geom.add_point([0.5, 1.0, 0.0], lcar)
+    s2 = geom.add_spline([p4, p3, p2, p1])
+
+    ll = geom.add_line_loop([s1, s2])
+    geom.add_plane_surface(ll)
+
+    ref = 1.0809439490373247
+    points, cells, _, _, _ = pygmsh.generate_mesh(geom)
+    assert abs(compute_volume(points, cells) - ref) < 1.0e-2 * ref
+    return points, cells
+
+
+if __name__ == '__main__':
+    import meshio
+    out = test()
+    meshio.write('splines.vtu', *out)


### PR DESCRIPTION
This is intended to fulfil #135.  All of the new code, including [`test/test_splines.py`](test/test_splines.py) is nearly identical to [`test/test_bsplines.py`](test/test_bsplines.py), is nearly identical to that for BSplines, though the shapes produced by the two tests differ markedly, as they should.
