### PR TITLE
version bump for interpolatory splines

### DIFF
--- a/pygmsh/__about__.py
+++ b/pygmsh/__about__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 
-__version__ = '4.0.7'
+__version__ = '4.0.8'
 __author__ = u'Nico Schlömer'
 __author_email__ = 'nico.schloemer@gmail.com'
 __website__ = 'https://github.com/nschloe/pygmsh'


### PR DESCRIPTION
I wondered why I didn't see [`pygmsh.built_in.Geometry.add_spline`](#136) in a fresh pip install.  Is it because that was added to v. 4.0.7 and the version hasn't incremented since?