### PR TITLE
Openc builtin

### DIFF
--- a/pygmsh/built_in/line_base.py
+++ b/pygmsh/built_in/line_base.py
@@ -5,6 +5,7 @@ import copy
 
 class LineBase(object):
     _ID = 0
+    dimension = 1
 
     def __init__(self, id0=None):
         if id0:

--- a/pygmsh/built_in/line_loop.py
+++ b/pygmsh/built_in/line_loop.py
@@ -4,6 +4,7 @@
 
 class LineLoop(object):
     _ID = 0
+    dimension = 1
 
     def __init__(self, lines):
         self.lines = lines

--- a/pygmsh/built_in/surface.py
+++ b/pygmsh/built_in/surface.py
@@ -6,6 +6,7 @@ from .line_loop import LineLoop
 class Surface(object):
     _ID = 0
     num_edges = 0
+    dimension = 2
 
     def __init__(self, line_loop, api_level=2):
         assert isinstance(line_loop, LineLoop)

--- a/pygmsh/built_in/surface_base.py
+++ b/pygmsh/built_in/surface_base.py
@@ -5,6 +5,7 @@
 class SurfaceBase(object):
     _ID = 0
     num_edges = 0
+    dimension = 2
 
     def __init__(self, id0=None, num_edges=0):
         isinstance(id0, str)

--- a/pygmsh/built_in/surface_loop.py
+++ b/pygmsh/built_in/surface_loop.py
@@ -4,6 +4,7 @@
 
 class SurfaceLoop(object):
     _ID = 0
+    dimension = 2
 
     def __init__(self, surfaces):
         self.surfaces = surfaces

--- a/pygmsh/built_in/volume_base.py
+++ b/pygmsh/built_in/volume_base.py
@@ -4,6 +4,7 @@
 
 class VolumeBase(object):
     _ID = 0
+    dimension = 3
 
     def __init__(self, id0=None):
         if id0:

--- a/pygmsh/opencascade/geometry.py
+++ b/pygmsh/opencascade/geometry.py
@@ -22,6 +22,7 @@ class Geometry(bl.Geometry):
             characteristic_length_min=None,
             characteristic_length_max=None
             ):
+        super().__init__()
         self._BOOLEAN_ID = 0
         self._EXTRUDE_ID = 0
         self._GMSH_CODE = [
@@ -40,7 +41,6 @@ class Geometry(bl.Geometry):
                 'Mesh.CharacteristicLengthMax = {};'.format(
                     characteristic_length_max
                     ))
-        super().__init__()
         return
 
     def get_code(self):

--- a/pygmsh/opencascade/geometry.py
+++ b/pygmsh/opencascade/geometry.py
@@ -13,9 +13,10 @@ from .surface_base import SurfaceBase
 from .torus import Torus
 from .wedge import Wedge
 from .volume_base import VolumeBase
+from ..built_in import geometry as bl
 
 
-class Geometry(object):
+class Geometry(bl.Geometry):
     def __init__(
             self,
             characteristic_length_min=None,
@@ -39,6 +40,7 @@ class Geometry(object):
                 'Mesh.CharacteristicLengthMax = {};'.format(
                     characteristic_length_max
                     ))
+        super().__init__()
         return
 
     def get_code(self):

--- a/pygmsh/opencascade/geometry.py
+++ b/pygmsh/opencascade/geometry.py
@@ -102,22 +102,22 @@ class Geometry(object):
         self._BOOLEAN_ID += 1
 
         # assert that all entities are of the same dimensionality
-        dim_type = None
+        dim = None
         legal_dim_types = {
-            # LineBase: 'Line',
-            SurfaceBase: 'Surface',
-            VolumeBase: 'Volume',
+            1: 'Line',
+            2: 'Surface',
+            3: 'Volume',
             }
         for ldt in legal_dim_types:
-            if isinstance(input_entities[0], ldt):
-                dim_type = ldt
+            if input_entities[0].dimension == ldt:
+                dim = ldt
                 break
-        assert dim_type is not None, \
+        assert dim is not None, \
             'Illegal input type \'{}\' for Boolean operation.'.format(
                 type(input_entities[0])
                 )
         for e in input_entities[1:] + tool_entities:
-            assert isinstance(e, dim_type), \
+            assert e.dimension == dim, \
                 'Incompatible input type \'{}\' for Boolean operation.'.format(
                     type(e)
                     )
@@ -128,15 +128,15 @@ class Geometry(object):
             .format(
                 name,
                 operation,
-                legal_dim_types[dim_type],
+                legal_dim_types[dim],
                 ','.join(e.id for e in input_entities),
                 'Delete;' if delete_first else '',
-                legal_dim_types[dim_type],
+                legal_dim_types[dim],
                 ','.join(e.id for e in tool_entities),
                 'Delete;' if delete_other else ''
                 ))
-
-        return dim_type(id0=name, is_list=True)
+        mapping = {'Line': None, 'Surface': SurfaceBase, 'Volume': VolumeBase}
+        return mapping[legal_dim_types[dim]](id0=name, is_list=True)
 
     def boolean_intersection(self, entities, delete_first=True, delete_other=True):
         '''Boolean intersection, see

--- a/pygmsh/opencascade/surface_base.py
+++ b/pygmsh/opencascade/surface_base.py
@@ -4,6 +4,7 @@
 
 class SurfaceBase(object):
     _ID = 0
+    dimension = 2
 
     def __init__(self, is_list=False, id0=None):
         isinstance(id0, str)

--- a/pygmsh/opencascade/volume_base.py
+++ b/pygmsh/opencascade/volume_base.py
@@ -4,6 +4,7 @@
 
 class VolumeBase(object):
     _ID = 0
+    dimension = 3
 
     def __init__(self, is_list=False, id0=None):
         isinstance(id0, str)

--- a/test/test_booleans.py
+++ b/test/test_booleans.py
@@ -1,0 +1,97 @@
+"""Test module for boolean operations."""
+import numpy as np
+
+import pygmsh
+
+from helpers import compute_volume
+
+
+def square_loop(geo_object):
+    """Construct square using built in geometry."""
+
+    p_arrays = [np.array([-0.5, -0.5, 0]), np.array([-0.5, 0.5, 0]),
+                np.array([0.5, 0.5, 0]), np.array([0.5, -0.5, 0])]
+    points = []
+    for point in p_arrays:
+        new_point = geo_object.add_point(point, 0.05)
+        points.append(new_point)
+    points = points + [points[0]]
+    lines = []
+    for point1, point2 in zip(points[:-1], points[1:]):
+        line = geo_object.add_line(point1, point2)
+        lines.append(line)
+    line_loop = geo_object.add_line_loop(lines)
+    return geo_object, line_loop
+
+
+def circle_loop(geo_object):
+    """construct circle using built_in geometry module."""
+    points = [geo_object.add_point(point, 0.05) for point in
+              [np.array([0., 0.1, 0.]),
+               np.array([-0.1, 0, 0]),
+               np.array([0, -0.1, 0]),
+               np.array([0.1, 0, 0])]]
+    points = points + [points[0]]
+    quarter_circles = [geo_object.add_circle_arc(point1,
+                                                 geo_object.add_point(
+                                                     [0, 0, 0],
+                                                     0.05),
+                                                 point2) for
+                       point1, point2 in zip(points[:-1], points[1:])]
+    line_loop = geo_object.add_line_loop(quarter_circles)
+    return geo_object, line_loop
+
+
+def built_in_opencascade_geos():
+    """Construct surface using builtin and boolean methods."""
+    # construct surface with hole using standard built in
+    geo_object = pygmsh.opencascade.Geometry(0.05, 0.05)
+    geo_object, square = square_loop(geo_object)
+    geo_object, circle = circle_loop(geo_object)
+    geo_object.add_plane_surface(square, [circle])
+
+    # construct surface using boolean
+    geo_object2 = pygmsh.opencascade.Geometry(0.05, 0.05)
+    geo_object2, square2 = square_loop(geo_object2)
+    geo_object2, line_loop2 = circle_loop(geo_object2)
+    surf1 = geo_object2.add_plane_surface(square2)
+    surf2 = geo_object2.add_plane_surface(line_loop2)
+
+    geo_object2.boolean_difference([surf1], [surf2])
+    return geo_object, geo_object2
+
+
+def built_in_opencascade_geos_fragments():
+    """Cconstruct surface using boolean fragments."""
+
+    geo_object = pygmsh.opencascade.Geometry(0.05, 0.05)
+    geo_object, square = square_loop(geo_object)
+    geo_object, line_loop = circle_loop(geo_object)
+    surf1 = geo_object.add_plane_surface(square)
+    surf2 = geo_object.add_plane_surface(line_loop)
+
+    geo_object.boolean_fragments([surf1], [surf2])
+    return geo_object
+
+
+def test_square_circle_hole():
+    """Test planar surface with holes.
+
+    Construct it with boolean operations and verify that it is the same.
+    """
+    for geo_object in built_in_opencascade_geos():
+        points, cells, _, _, _ = pygmsh.generate_mesh(geo_object)
+        surf = 1 - 0.1 ** 2 * np.pi
+        assert np.abs((compute_volume(points, cells) - surf) / surf) < 1e-3
+
+
+def test_square_circle_slice():
+    """Test planar suface square with circular hole."""
+    geo_object = built_in_opencascade_geos_fragments()
+    points, cells, _, _, _ = pygmsh.generate_mesh(geo_object)
+    assert np.abs((compute_volume(points, cells) - 1) / 1) < 1e-3
+
+
+if __name__ == '__main__':
+    test_square_circle_hole()
+    test_square_circle_slice()


### PR DESCRIPTION
The objective is to use opencascade and builtin geometries together in boolean operations as gmsh allows it. 
The main changes are the following:
- built_in.Geometry becomes parent of opencascade.Geometry. That works very smoothly as long as the _bollean_operations is updated.
- insertion of topological dimension for each base class in built_in and opencascade by inserting a property named dimension.
- Use of that property to treat both geometry factories together within _boolean_operations
- That also replaces the use of isinstance with dimension testing in that method.
- Addition of tests using plane surfaces that test both square surface with a circular hole as well as square circle fragments. Square and circle are built using built_in geometry type, namely line_loop then PlaneSurface, but passing through the opencascade factory. Then boolean operations are called. 