### PR TITLE
need more than one point to make a {Bs,S}pline #150 #151

### DIFF
--- a/pygmsh/built_in/bspline.py
+++ b/pygmsh/built_in/bspline.py
@@ -10,7 +10,7 @@ class Bspline(LineBase):
 
         for c in control_points:
             assert isinstance(c, Point)
-        assert len(control_points) > 3
+        assert len(control_points) > 1
 
         self.control_points = control_points
 

--- a/pygmsh/built_in/spline.py
+++ b/pygmsh/built_in/spline.py
@@ -10,7 +10,7 @@ class Spline(LineBase):
 
         for c in points:
             assert isinstance(c, Point)
-        assert len(control_points) > 1
+        assert len(points) > 1
 
         self.points = points
 

--- a/pygmsh/built_in/spline.py
+++ b/pygmsh/built_in/spline.py
@@ -10,6 +10,7 @@ class Spline(LineBase):
 
         for c in points:
             assert isinstance(c, Point)
+        assert len(control_points) > 1
 
         self.points = points
 


### PR DESCRIPTION
Gmsh crashes if BSpline has only one point and throws an error if Spline does, so here insist on more.
