### PR TITLE
Fix issue with extrusion volume id in #162

### DIFF
--- a/pygmsh/opencascade/geometry.py
+++ b/pygmsh/opencascade/geometry.py
@@ -219,6 +219,6 @@ class Geometry(bl.Geometry):
         extruded = '{}[1]'.format(name)
 
         top = SurfaceBase(top)
-        extruded = VolumeBase(extruded)
+        extruded = VolumeBase(is_list=False, id0=extruded)
 
         return top, extruded


### PR DESCRIPTION
the id returned from the extrude was incorrect, it needs to be based on the extrude array.  Fixes #162 