### PR TITLE
transforming circles

### DIFF
--- a/test/test_circle_transform.py
+++ b/test/test_circle_transform.py
@@ -1,39 +1,32 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from numpy import array, pi, sin, cos
+import numpy as np
 import pygmsh
 
 from helpers import compute_volume
 
 
 
-def test():
+def test(radius=1.):
     geom = pygmsh.built_in.Geometry()
 
-    theta = pi / array([2., 3., 5])
-    R = [array([[1, 0, 0],
-                [0, cos(theta[0]), -sin(theta[0])],
-                [0, sin(theta[0]), cos(theta[0])]]),
-         array([[cos(theta[1]), 0, sin(theta[1])],
-                [0, 1, 0],
-                [-sin(theta[1]), 0, cos(theta[1])]]),
-         array([[cos(theta[2]), -sin(theta[2]), 0],
-                [sin(theta[2]), cos(theta[2]), 0],
-                [0, 0, 1]])]
+    theta = np.pi / np.array([2., 3., 5])
+    R = [pygmsh.rotation_matrix(np.eye(1, 3, d)[0], np.pi / 2)
+         for d in range(3)]
 
     geom.add_circle(
         [7., 11., 13.],
-        1.,
+        radius,
         .1,
         R[0] @ R[1] @ R[2])
 
-    ref = 3.1363871677682247
+    ref = np.pi * radius ** 2
     points, cells, _, _, _ = pygmsh.generate_mesh(geom)
-    assert abs(compute_volume(points, cells) - ref) < 1.0e-2 * ref
+    assert np.isclose(compute_volume(points, cells), ref, rtol=1e-2)
     return points, cells
 
 
 if __name__ == '__main__':
     import meshio
-    meshio.write('circle.vtk', *test())
+    meshio.write('circle_transformed.vtk', *test())

--- a/test/test_circle_transform.py
+++ b/test/test_circle_transform.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
+
+from numpy import array, pi, sin, cos
 import pygmsh
 
 from helpers import compute_volume
 
-from numpy import array, pi, sin, cos
 
 
 def test():

--- a/test/test_circle_transform.py
+++ b/test/test_circle_transform.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+import pygmsh
+
+from helpers import compute_volume
+
+from numpy import array, pi, sin, cos
+
+
+def test():
+    geom = pygmsh.built_in.Geometry()
+
+    theta = pi / array([2., 3., 5])
+    R = [array([[1, 0, 0],
+                [0, cos(theta[0]), -sin(theta[0])],
+                [0, sin(theta[0]), cos(theta[0])]]),
+         array([[cos(theta[1]), 0, sin(theta[1])],
+                [0, 1, 0],
+                [-sin(theta[1]), 0, cos(theta[1])]]),
+         array([[cos(theta[2]), -sin(theta[2]), 0],
+                [sin(theta[2]), cos(theta[2]), 0],
+                [0, 0, 1]])]
+                   
+    geom.add_circle(
+        [7., 11., 13.],
+        1.,
+        .1,
+        R[0] @ R[1] @ R[2])
+
+    ref = 3.1363871677682247
+    points, cells, _, _, _ = pygmsh.generate_mesh(geom)
+    assert abs(compute_volume(points, cells) - ref) < 1.0e-2 * ref
+    return points, cells
+
+
+if __name__ == '__main__':
+    import meshio
+    meshio.write('circle.vtk', *test())

--- a/test/test_circle_transform.py
+++ b/test/test_circle_transform.py
@@ -11,9 +11,8 @@ from helpers import compute_volume
 def test(radius=1.):
     geom = pygmsh.built_in.Geometry()
 
-    theta = np.pi / np.array([2., 3., 5])
-    R = [pygmsh.rotation_matrix(np.eye(1, 3, d)[0], np.pi / 2)
-         for d in range(3)]
+    R = [pygmsh.rotation_matrix(np.eye(1, 3, d)[0], theta)
+         for d, theta in enumerate(np.pi / np.array([2., 3., 5]))]
 
     geom.add_circle(
         [7., 11., 13.],

--- a/test/test_circle_transform.py
+++ b/test/test_circle_transform.py
@@ -20,7 +20,7 @@ def test():
          array([[cos(theta[2]), -sin(theta[2]), 0],
                 [sin(theta[2]), cos(theta[2]), 0],
                 [0, 0, 1]])]
-                   
+
     geom.add_circle(
         [7., 11., 13.],
         1.,


### PR DESCRIPTION
This addresses the issues identified in transforming circles #173:

- the transformation changed the type of the point coordinates from a two-dimensional array to a list of one-dimensional arrays
- the transformation also performed the offset, so that it was done twice if a transform was specified

It also:
- fulfils the TODO in Geometry.add_circle to assert that `R` preserves circles
- provides a new test of an offset transformed circle

The formulæ for the transformation used are taken from https://en.wikipedia.org/wiki/Rotation_matrix#General_rotations.

The test is otherwise based on `test/test_circle.py` but does not specify `compound=True` as that is currently broken #112 .