### PR TITLE
test volume of tori using exact formula

### DIFF
--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -254,10 +254,11 @@ class Geometry(object):
                 for k in range(num_sections)
                 ])
 
-        # Apply the transformation.
         if R is not None:
-            # Assert that the transformation preserves circles
-            assert numpy.allclose(abs(numpy.linalg.eigvals(R)), 1.)
+            assert numpy.allclose(abs(numpy.linalg.eigvals(R)),
+                                  numpy.ones(X.shape[1])), \
+                   "The transformation matrix doesn't preserve circles;" \
+                   " at least one eigenvalue lies off the unit circle."
             X = X @ R.T
 
         X += x0

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -255,9 +255,10 @@ class Geometry(object):
                 ])
 
         # Apply the transformation.
-        # TODO assert that the transformation preserves circles
         if R is not None:
-            X = [numpy.dot(R, x) + x0 for x in X]
+            # Assert that the transformation preserves circles
+            assert numpy.allclose(abs(numpy.linalg.eigvals(R)), 1.)
+            X = X @ R.T
 
         X += x0
 

--- a/test/test_tori.py
+++ b/test/test_tori.py
@@ -7,36 +7,30 @@ import pygmsh
 from helpers import compute_volume
 
 
-def test():
+def test(irad=0.05,
+         orad=0.6):
     '''Torus, rotated in space.
     '''
     geom = pygmsh.built_in.Geometry()
 
-    R = np.array([
-        [1.0, 0.0, 0.0],
-        [0.0, 0.0, 1.0],
-        [0.0, 1.0, 0.0]
-        ])
+    R = pygmsh.rotation_matrix([1., 0., 0.], np.pi / 2)
     geom.add_torus(
-        irad=0.05, orad=0.6, lcar=0.03,
+        irad=irad, orad=orad, lcar=0.03,
         x0=[0.0, 0.0, -1.0],
         R=R
         )
 
-    R = np.array([
-        [0.0, 0.0, 1.0],
-        [0.0, 1.0, 0.0],
-        [1.0, 0.0, 0.0]
-        ])
+    R = pygmsh.rotation_matrix([0., 1., 0.], np.pi / 2)
     geom.add_torus(
-        irad=0.05, orad=0.6, lcar=0.03,
+        irad=irad, orad=orad, lcar=0.03,
         x0=[0.0, 0.0, 1.0],
         variant='extrude_circle'
         )
 
-    ref = 0.06604540601899624
+    ref = 2 * 2 * np.pi **2 * orad * irad ** 2
     points, cells, _, _, _ = pygmsh.generate_mesh(geom)
-    assert abs(compute_volume(points, cells) - ref) < 1.0e-2 * ref
+    assset np.isclose(compute_volume(points, cells), ref,
+                      rtol=5e-2)
     return points, cells
 
 

--- a/test/test_tori.py
+++ b/test/test_tori.py
@@ -27,9 +27,9 @@ def test(irad=0.05,
         variant='extrude_circle'
         )
 
-    ref = 2 * 2 * np.pi **2 * orad * irad ** 2
+    ref = 2 * 2 * np.pi ** 2 * orad * irad ** 2
     points, cells, _, _, _ = pygmsh.generate_mesh(geom)
-    assset np.isclose(compute_volume(points, cells), ref,
+    assert np.isclose(compute_volume(points, cells), ref,
                       rtol=5e-2)
     return points, cells
 

--- a/test/test_torus.py
+++ b/test/test_torus.py
@@ -7,22 +7,23 @@ import pygmsh
 from helpers import compute_volume
 
 
-def test():
+def test(irad=0.05,
+         orad=0.6):
     '''Torus, rotated in space.
     '''
     geom = pygmsh.built_in.Geometry()
 
-    radii = [0.05, 0.6]
     R = pygmsh.rotation_matrix([1., 0., 0.], np.pi / 2)
     geom.add_torus(
-        irad=radii[0], orad=radii[1], lcar=0.03,
+        irad=irad, orad=orad, lcar=0.03,
         x0=[0.0, 0.0, -1.0],
         R=R
         )
 
-    ref = 2 * np.pi ** 2 * radii[0] ** 2 * radii[1]
+    ref = 2 * np.pi ** 2 * orad * irad ** 2
     points, cells, _, _, _ = pygmsh.generate_mesh(geom)
-    assert abs(compute_volume(points, cells) - ref) < 5.0e-2 * ref
+    assert np.isclose(compute_volume(points, cells), ref,
+                      rtol=5e-2)
     return points, cells
 
 

--- a/test/test_torus.py
+++ b/test/test_torus.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pygmsh
+
+from helpers import compute_volume
+
+
+def test():
+    '''Torus, rotated in space.
+    '''
+    geom = pygmsh.built_in.Geometry()
+
+    radii = [0.05, 0.6]
+    R = pygmsh.rotation_matrix([1., 0., 0.], np.pi / 2)
+    geom.add_torus(
+        irad=radii[0], orad=radii[1], lcar=0.03,
+        x0=[0.0, 0.0, -1.0],
+        R=R
+        )
+
+    ref = 2 * np.pi ** 2 * radii[0] ** 2 * radii[1]
+    points, cells, _, _, _ = pygmsh.generate_mesh(geom)
+    assert abs(compute_volume(points, cells) - ref) < 5.0e-2 * ref
+    return points, cells
+
+
+if __name__ == '__main__':
+    import meshio
+    meshio.write('torus.vtu', *test())

--- a/test/test_torus_crowd.py
+++ b/test/test_torus_crowd.py
@@ -64,9 +64,9 @@ def test():
         lcar=0.3
         )
 
-    ref = 15.276653079300184
+    ref = len(A1) * 2 * np.pi ** 2 * orad * irad ** 2 + 2.0 ** 3
     points, cells, _, _, _ = pygmsh.generate_mesh(geom)
-    assert abs(compute_volume(points, cells) - ref) < 1.0e-2 * ref
+    assert np.isclose(compute_volume(points, cells), ref, rtol=2e-2)
     return points, cells
 
 


### PR DESCRIPTION
This demonstrates the exact formula for the volume of a torus #176 .  From `test_tori.py`, it drops the second torus which was constructed with `_add_torus_extrude_circle` which calls `add_compound_volume` which fails on my machine with Gmsh 3.0.7 because of the issue with compound entities #112.

I did have to increase the relative tolerance from 0.01 to 0.05.  The original tighter value can be achieved by reducing `lcar` but that makes the test take longer.