### PR TITLE
Fixed typo in index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,7 +23,7 @@ Contents:
 
 
 :mod:`pygmsh.opencascade.geometry`
-===============================
+==================================
 
 .. automodule:: pygmsh.opencascade.geometry
     :members:


### PR DESCRIPTION
There was a typo in the underline of a heading in index.rst that prevented sphynx from compiling the docs. 