### PR TITLE
Add optional flag to the definition of transfinite lines/surface.

### DIFF
--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -186,7 +186,7 @@ class Geometry(object):
             ", ".join([l.id for l in lines]), size
         )
         if optional_argument is not None:
-            code += optional_argument
+            code += ' ' + optional_argument
         self._GMSH_CODE.append(code + ";")
         return
 
@@ -205,9 +205,9 @@ class Geometry(object):
             self.set_transfinite_lines(
                 [surface.line_loop.lines[1], surface.line_loop.lines[3]], size[1]
             )
-        code = "Transfinite Surface {{{}}};".format(surface.id)
+        code = "Transfinite Surface {{{}}}".format(surface.id)
         if optional_argument is not None:
-            code += optional_argument
+            code += ' ' + optional_argument
         self._GMSH_CODE.append(code + ";")
         return
 

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -181,22 +181,16 @@ class Geometry(object):
         self._add_physical("Volume", volumes, label=label)
         return
 
-    def set_transfinite_lines(self, lines, size, flag=None):
-        if flag is not None:
-            self._GMSH_CODE.append(
-                "Transfinite Line {{{0}}} = {1} {2};".format(
-                    ", ".join([l.id for l in lines]), size, flag
-                )
-            )
-        else:
-            self._GMSH_CODE.append(
-                "Transfinite Line {{{0}}} = {1};".format(
-                    ", ".join([l.id for l in lines]), size
-                )
-            )
+    def set_transfinite_lines(self, lines, size, optional_argument=None):
+        code = "Transfinite Line {{{0}}} = {1}".format(
+            ", ".join([l.id for l in lines]), size
+        )
+        if optional_argument is not None:
+            code += optional_argument
+        self._GMSH_CODE.append(code + ";")
         return
 
-    def set_transfinite_surface(self, surface, size=None, flag=None):
+    def set_transfinite_surface(self, surface, size=None, optional_argument=None):
         assert surface.num_edges == 4, "a transfinite surface can only have 4 sides"
         # size is not mandatory because in general a user can create it's own
         # transfinite lines and then just tell gmsh that the surface is
@@ -211,12 +205,10 @@ class Geometry(object):
             self.set_transfinite_lines(
                 [surface.line_loop.lines[1], surface.line_loop.lines[3]], size[1]
             )
-        if flag is not None:
-            self._GMSH_CODE.append(
-                "Transfinite Surface {{{}}} {};".format(surface.id, flag)
-            )
-        else:
-            self._GMSH_CODE.append("Transfinite Surface {{{}}};".format(surface.id))
+        code = "Transfinite Surface {{{}}};".format(surface.id)
+        if optional_argument is not None:
+            code += optional_argument
+        self._GMSH_CODE.append(code + ";")
         return
 
     def add_circle(

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -186,7 +186,7 @@ class Geometry(object):
             ", ".join([l.id for l in lines]), size
         )
         if optional_argument is not None:
-            code += ' ' + optional_argument
+            code += " " + optional_argument
         self._GMSH_CODE.append(code + ";")
         return
 
@@ -207,7 +207,7 @@ class Geometry(object):
             )
         code = "Transfinite Surface {{{}}}".format(surface.id)
         if optional_argument is not None:
-            code += ' ' + optional_argument
+            code += " " + optional_argument
         self._GMSH_CODE.append(code + ";")
         return
 

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -181,16 +181,21 @@ class Geometry(object):
         self._add_physical("Volume", volumes, label=label)
         return
 
-    def set_transfinite_lines(self, lines, size, optional_argument=None):
+    def set_transfinite_lines(self, lines, size, progression=None, bump=None):
         code = "Transfinite Line {{{0}}} = {1}".format(
             ", ".join([l.id for l in lines]), size
         )
-        if optional_argument is not None:
-            code += " " + optional_argument
+        assert (
+            progression is not None and bump is not None
+        ), "only one optional argument possible: progression or bump"
+        if progression is not None:
+            code += " Using Progression " + progression
+        elif bump is not None:
+            code += " Using Bump " + bump
         self._GMSH_CODE.append(code + ";")
         return
 
-    def set_transfinite_surface(self, surface, size=None, optional_argument=None):
+    def set_transfinite_surface(self, surface, size=None, orientation=None):
         assert surface.num_edges == 4, "a transfinite surface can only have 4 sides"
         # size is not mandatory because in general a user can create it's own
         # transfinite lines and then just tell gmsh that the surface is
@@ -206,8 +211,8 @@ class Geometry(object):
                 [surface.line_loop.lines[1], surface.line_loop.lines[3]], size[1]
             )
         code = "Transfinite Surface {{{}}}".format(surface.id)
-        if optional_argument is not None:
-            code += " " + optional_argument
+        if orientation is not None:
+            code += " " % orientation
         self._GMSH_CODE.append(code + ";")
         return
 

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -181,15 +181,22 @@ class Geometry(object):
         self._add_physical("Volume", volumes, label=label)
         return
 
-    def set_transfinite_lines(self, lines, size):
-        self._GMSH_CODE.append(
-            "Transfinite Line {{{0}}} = {1};".format(
-                ", ".join([l.id for l in lines]), size
+    def set_transfinite_lines(self, lines, size, flag=None):
+        if flag is not None:
+            self._GMSH_CODE.append(
+                "Transfinite Line {{{0}}} = {1} {2};".format(
+                    ", ".join([l.id for l in lines]), size, flag
+                )
             )
-        )
+        else:
+            self._GMSH_CODE.append(
+                "Transfinite Line {{{0}}} = {1};".format(
+                    ", ".join([l.id for l in lines]), size
+                )
+            )
         return
 
-    def set_transfinite_surface(self, surface, size=None):
+    def set_transfinite_surface(self, surface, size=None, flag=None):
         assert surface.num_edges == 4, "a transfinite surface can only have 4 sides"
         # size is not mandatory because in general a user can create it's own
         # transfinite lines and then just tell gmsh that the surface is
@@ -204,7 +211,10 @@ class Geometry(object):
             self.set_transfinite_lines(
                 [surface.line_loop.lines[1], surface.line_loop.lines[3]], size[1]
             )
-        self._GMSH_CODE.append("Transfinite Surface {{{}}};".format(surface.id))
+        if flag is not None:
+            self._GMSH_CODE.append("Transfinite Surface {{{}}} {};".format(surface.id, flag))
+        else:
+            self._GMSH_CODE.append("Transfinite Surface {{{}}};".format(surface.id))
         return
 
     def add_circle(

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -188,9 +188,9 @@ class Geometry(object):
         if progression is not None and bump is not None:
             raise ValueError("only one optional argument possible", progression, bump)
         elif progression is not None:
-            code += " Using Progression " + progression
+            code += " Using Progression " + str(progression)
         elif bump is not None:
-            code += " Using Bump " + bump
+            code += " Using Bump " + str(bump)
         self._GMSH_CODE.append(code + ";")
         return
 
@@ -211,7 +211,7 @@ class Geometry(object):
             )
         code = "Transfinite Surface {{{}}}".format(surface.id)
         if orientation is not None:
-            code += " " % orientation
+            code += " " + orientation
         self._GMSH_CODE.append(code + ";")
         return
 

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -185,10 +185,9 @@ class Geometry(object):
         code = "Transfinite Line {{{0}}} = {1}".format(
             ", ".join([l.id for l in lines]), size
         )
-        assert (
-            progression is not None and bump is not None
-        ), "only one optional argument possible: progression or bump"
-        if progression is not None:
+        if progression is not None and bump is not None:
+            raise ValueError("only one optional argument possible", progression, bump)
+        elif progression is not None:
             code += " Using Progression " + progression
         elif bump is not None:
             code += " Using Bump " + bump

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -212,7 +212,9 @@ class Geometry(object):
                 [surface.line_loop.lines[1], surface.line_loop.lines[3]], size[1]
             )
         if flag is not None:
-            self._GMSH_CODE.append("Transfinite Surface {{{}}} {};".format(surface.id, flag))
+            self._GMSH_CODE.append(
+                "Transfinite Surface {{{}}} {};".format(surface.id, flag)
+            )
         else:
             self._GMSH_CODE.append("Transfinite Surface {{{}}};".format(surface.id))
         return


### PR DESCRIPTION
The intention of this is to allow the provision of options when defining transfinite items, e.g.
```
geom.set_transfinite_lines([l0, l2], size=10, flag="Using Bump 0.1")
geom.set_transfinite_surface(mysurf, size=None, flag="Alternate")
```