### PR TITLE
minimal fix of generate_mesh for #200

### DIFF
--- a/pygmsh/helpers.py
+++ b/pygmsh/helpers.py
@@ -153,7 +153,7 @@ def generate_mesh(
                 mesh.point_data,
                 mesh.cell_data,
                 mesh.field_data)
-                
+
     if num_lloyd_steps > 0:
         if verbose:
             print('Lloyd smoothing...')
@@ -162,7 +162,8 @@ def generate_mesh(
         # the mesh as a whole.
         # a = mesh.cell_data['triangle']['geometrical']
         # https://stackoverflow.com/q/42740483/353337
-        submesh_bools = {0: numpy.ones(len(mesh.cells['triangle']), dtype=bool)}
+        submesh_bools = {0: numpy.ones(len(mesh.cells['triangle']),
+                                       dtype=bool)}
 
         mesh.points, mesh.cells['triangle'] = voropy.smoothing.lloyd_submesh(
                 mesh.points, mesh.cells['triangle'], submesh_bools,


### PR DESCRIPTION
This is a minimal fix to `pygmsh.helpers.generate_mesh` to cope with the new container returned by meshio.read. nschloe/meshio#250 #200 

It's minimal in that it only uses the container internally and breaks it back up into its constituents before returning.  I imagine that eventually it will be preferred to make direct use of the meshio.Mesh container in pygmsh and downstream applications like [kinnala/scikit-fem](https://github.com/kinnala/scikit-fem), but here that requires changing most of pygmsh/test scripts individually. 

With this change, the number of failures reported in #200 reduces from 42 to 4; I think they're due to compound entities in Gmsh #112 .