### PR TITLE
test bspline according to Gmsh < 4, fixes #220

### DIFF
--- a/test/test_bsplines.py
+++ b/test/test_bsplines.py
@@ -21,7 +21,7 @@ def test():
     ll = geom.add_line_loop([s1, s2])
     geom.add_plane_surface(ll)
 
-    ref = 0.9156598733673261
+    ref = 0.9156598733673261 if pygmsh.get_gmsh_major_version() < 4 else 0.75
     points, cells, _, _, _ = pygmsh.generate_mesh(geom)
     assert abs(compute_volume(points, cells) - ref) < 1.0e-2 * ref
     return points, cells


### PR DESCRIPTION
I believe it works for Gmsh < 4 and for Gmsh 4, so it should be ready for inclusion now,  unlike #214 for the Gmsh 4 compound entities.

Tested with 3.0.6 and 4.0.1-git-296dd75f0.