### PR TITLE
Define constant

### DIFF
--- a/pygmsh/built_in/define_constant.py
+++ b/pygmsh/built_in/define_constant.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+
+
+class DefineConstant(object):
+    def __init__(self, label, value, min_value, max_value, step=None, name=None):
+        assert min_value <= value <= max_value
+
+        self.label = label
+
+        if name is None:
+            name = "Parameters/{}".format(label)
+
+        step = "" if step is None else "Step {}".format(step)
+
+        self.code = 'DefineConstant[ {} = {{ {}, Min {}, Max {}, {}, Name "{}" }} ];'.format(
+            label, value, min_value, max_value, step, name
+        )
+        return
+
+    # Need to overload repr so that the label will be formatted into gmsh code without and quotes
+    def __repr__(self):
+        return self.label

--- a/pygmsh/built_in/define_constant.py
+++ b/pygmsh/built_in/define_constant.py
@@ -18,6 +18,6 @@ class DefineConstant(object):
         )
         return
 
-    # Need to overload repr so that the label will be formatted into gmsh code without and quotes
+    # Need to overload repr so that the label will be formatted into gmsh code without any quotes
     def __repr__(self):
         return self.label

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -25,6 +25,7 @@ from .circle_arc import CircleArc
 from .compound_line import CompoundLine
 from .compound_surface import CompoundSurface
 from .compound_volume import CompoundVolume
+from .define_constant import DefineConstant
 from .dummy import Dummy
 from .ellipse_arc import EllipseArc
 from .line import Line
@@ -142,6 +143,11 @@ class Geometry(object):
 
     def add_volume(self, *args, **kwargs):
         e = Volume(*args, **kwargs)
+        self._GMSH_CODE.append(e.code)
+        return e
+
+    def define_constant(self, *args, **kwargs):
+        e = DefineConstant(*args, **kwargs)
         self._GMSH_CODE.append(e.code)
         return e
 


### PR DESCRIPTION
Adds the ability to add a DefineConstant to the pygmsh code. Also makes it possible to use the DefineConstant label in specifying points etc.

The intention is to make it easier to adjust the mesh in the gmsh gui, or by passing in command line arguments during meshing. 