### PR TITLE
Fix meshio example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To store the mesh, you can use [meshio](https://pypi.org/project/meshio);
 for example
 ```python
 import meshio
-meshio.write('test.vtu', points, cells, cell_data=cell_data)
+meshio.write_points_cells('test.vtk', points, cells, cell_data=cell_data)
 ```
 The output file can be visualized with various tools, e.g.,
 [ParaView](https://www.paraview.org/).


### PR DESCRIPTION
Use the correct meshio write helper, and switch to the .vtk
format to avoid depending on the lxml module, which is not
strictly required by meshio and thus likely won't have been
installed by a beginner.

This resolves issue #234.