### PR TITLE
[WIP] Improve extrude capabilities

### DIFF
--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -353,6 +353,8 @@ class Geometry(object):
 
         if _is_string(input_entity):
             entity = Dummy(input_entity)
+        elif isinstance(input_entity, Point):
+            entity = Dummy("Point{{{}}}".format(input_entity.id))
         elif isinstance(input_entity, SurfaceBase):
             entity = Dummy("Surface{{{}}}".format(input_entity.id))
         elif hasattr(input_entity, "surface"):
@@ -419,6 +421,9 @@ class Geometry(object):
         elif isinstance(input_entity, SurfaceBase):
             top = SurfaceBase(top, input_entity.num_edges)
             extruded = VolumeBase(extruded)
+        elif isinstance(input_entity, Point):
+            top = Point(top)
+            extruded = LineBase(extruded)
         else:
             top = Dummy(top)
             extruded = Dummy(extruded)

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -19,6 +19,7 @@ from .line_base import LineBase
 from .line_loop import LineLoop
 from .plane_surface import PlaneSurface
 from .point import Point
+from .point_base import PointBase
 from .spline import Spline
 from .surface import Surface
 from .surface_base import SurfaceBase
@@ -353,7 +354,7 @@ class Geometry(object):
 
         if _is_string(input_entity):
             entity = Dummy(input_entity)
-        elif isinstance(input_entity, Point):
+        elif isinstance(input_entity, PointBase):
             entity = Dummy("Point{{{}}}".format(input_entity.id))
         elif isinstance(input_entity, SurfaceBase):
             entity = Dummy("Surface{{{}}}".format(input_entity.id))
@@ -421,8 +422,8 @@ class Geometry(object):
         elif isinstance(input_entity, SurfaceBase):
             top = SurfaceBase(top, input_entity.num_edges)
             extruded = VolumeBase(extruded)
-        elif isinstance(input_entity, Point):
-            top = Point(top)
+        elif isinstance(input_entity, PointBase):
+            top = PointBase(top)
             extruded = LineBase(extruded)
         else:
             top = Dummy(top)

--- a/pygmsh/built_in/point.py
+++ b/pygmsh/built_in/point.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
+from .point_base import PointBase
 
 
-class Point(object):
+class Point(PointBase):
     """
     Creates an elementary point.
 
@@ -13,14 +14,11 @@ class Point(object):
         The prescribed mesh element size at this point.
     """
 
-    _POINT_ID = 0
-
     def __init__(self, x, lcar=None):
+        super(Point, self).__init__()
+
         self.x = x
         self.lcar = lcar
-
-        self.id = "p{}".format(Point._POINT_ID)
-        Point._POINT_ID += 1
 
         # Points are always 3D in gmsh
         if lcar is not None:

--- a/pygmsh/built_in/point_base.py
+++ b/pygmsh/built_in/point_base.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+
+
+class PointBase(object):
+    """
+    Increments the Point ID every time a new object
+    is created that inherits from PointBase.
+
+    Parameters
+    ----------
+    id0 : str
+        If no unique ID is given, the object global is incremented.
+    """
+
+    _ID = 0
+
+    def __init__(self, id0=None):
+        if id0:
+            self.id = id0
+        else:
+            self.id = "p{}".format(PointBase._ID)
+            PointBase._ID += 1
+        return

--- a/pygmsh/opencascade/dummy.py
+++ b/pygmsh/opencascade/dummy.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-#
-
-
-class Dummy(object):
-    def __init__(self, id0):
-        self.id = id0
-        return

--- a/pygmsh/opencascade/geometry.py
+++ b/pygmsh/opencascade/geometry.py
@@ -2,14 +2,11 @@
 #
 from ..__about__ import __version__
 
-from .. import built_in
-
 from .ball import Ball
 from .box import Box
 from .cone import Cone
 from .cylinder import Cylinder
 from .disk import Disk
-from .dummy import Dummy
 from .rectangle import Rectangle
 from .surface_base import SurfaceBase
 from .torus import Torus
@@ -203,39 +200,3 @@ class Geometry(bl.Geometry):
         and tool_entity are called object and tool in gmsh documentation.
         """
         return self._boolean_operation("BooleanFragments", *args, **kwargs)
-
-    def extrude(self, input_entity, translation_axis):
-        """Extrusion (translation + rotation) of any entity along a given
-        translation_axis, around a given rotation_axis, about a given angle. If
-        one of the entities is not provided, this method will produce only
-        translation or rotation.
-        """
-        self._EXTRUDE_ID += 1
-
-        assert isinstance(input_entity, built_in.surface_base.SurfaceBase)
-        entity = Dummy("Surface{{{}}}".format(input_entity.id))
-
-        # out[] = Extrude{0,1,0}{ Line{1}; };
-        name = "ex{}".format(self._EXTRUDE_ID)
-
-        # Only translation
-        self._GMSH_CODE.append(
-            "{}[] = Extrude{{{}}}{{{};}};".format(
-                name, ",".join(repr(x) for x in translation_axis), entity.id
-            )
-        )
-
-        # From <https://www.manpagez.com/info/gmsh/gmsh-2.4.0/gmsh_66.php>:
-        #
-        # > In this last extrusion command we retrieved the volume number
-        # > programatically by saving the output of the command into a
-        # > list. This list will contain the "top" of the extruded surface (in
-        # > out[0]) as well as the newly created volume (in out[1]).
-        #
-        top = "{}[0]".format(name)
-        extruded = "{}[1]".format(name)
-
-        top = SurfaceBase(top)
-        extruded = VolumeBase(is_list=False, id0=extruded)
-
-        return top, extruded

--- a/test/test_extrusion_entities.py
+++ b/test/test_extrusion_entities.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Create several entities by extrusion, check that the expected
+sub-entities are returned and the resulting mesh is correct.
+"""
+import pygmsh
+import numpy as np
+
+
+def test():
+    kernels = [pygmsh.built_in, pygmsh.opencascade]
+    for kernel in kernels:
+        geom = kernel.Geometry()
+        p = geom.add_point([0, 0, 0], 1)
+        p_top, _, _ = geom.extrude(p, translation_axis=[1, 0, 0])
+
+        # The mesh should now contain exactly two points,
+        # the second one should be where the translation pointed.
+        points, _, _, _, _ = pygmsh.generate_mesh(geom)
+        assert len(points) == 2
+        assert np.array_equal(points[-1], [1, 0, 0])
+
+        # Check that the top entity (a PointBase) can be extruded correctly
+        # again.
+        _, _, _ = geom.extrude(p_top, translation_axis=[1, 0, 0])
+        points, _, _, _, _ = pygmsh.generate_mesh(geom)
+        assert len(points) == 3
+        assert np.array_equal(points[-1], [2, 0, 0])
+
+        # Set up new geometry with one line.
+        geom = kernel.Geometry()
+        p1 = geom.add_point([0, 0, 0], 1)
+        p2 = geom.add_point([1, 0, 0], 1)
+        line = geom.add_line(p1, p2)
+
+        l_top, _, _ = geom.extrude(line, [0, 1, 0])
+        points, _, _, _, _ = pygmsh.generate_mesh(geom)
+        assert len(points) == 5
+        assert np.array_equal(points[-2], [1, 1, 0])
+
+        # Check again for top entity (a LineBase).
+        _, _, _ = geom.extrude(l_top, [0, 1, 0])
+        points, _, _, _, _ = pygmsh.generate_mesh(geom)
+        assert len(points) == 8
+        assert np.array_equal(points[-3], [1, 2, 0])

--- a/test/test_opencascade_regular_extrusion.py
+++ b/test/test_opencascade_regular_extrusion.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Creates regular cube mesh by extrusion.
+"""
+import pygmsh
+
+from helpers import compute_volume
+
+
+def test():
+    x = 5
+    y = 4
+    z = 3
+    x_layers = 10
+    y_layers = 5
+    z_layers = 3
+    geom = pygmsh.opencascade.Geometry()
+    p = geom.add_point([0, 0, 0], 1)
+    _, l, _ = geom.extrude(p, [x, 0, 0], num_layers=x_layers)
+    _, s, _ = geom.extrude(l, [0, y, 0], num_layers=y_layers)
+    geom.extrude(s, [0, 0, z], num_layers=z_layers)
+    points, cells, _, _, _ = pygmsh.generate_mesh(geom)
+
+    ref_vol = x * y * z
+    assert abs(compute_volume(points, cells) - ref_vol) < 1.0e-2 * ref_vol
+
+    # Each grid-cell from layered extrusion will result in 6 tetrahedrons.
+    ref_tetras = 6 * x_layers * y_layers * z_layers
+    assert len(cells["tetra"]) == ref_tetras
+
+    return points, cells
+
+
+if __name__ == "__main__":
+    import meshio
+
+    meshio.write_points_cells("cube.vtu", *test())

--- a/test/test_regular_extrusion.py
+++ b/test/test_regular_extrusion.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Creates regular cube mesh by extrusion.
+"""
+import pygmsh
+
+from helpers import compute_volume
+
+
+def test():
+    x = 5
+    y = 4
+    z = 3
+    x_layers = 10
+    y_layers = 5
+    z_layers = 3
+    geom = pygmsh.built_in.Geometry()
+    p = geom.add_point([0, 0, 0], 1)
+    _, l, _ = geom.extrude(p, [x, 0, 0], num_layers=x_layers)
+    _, s, _ = geom.extrude(l, [0, y, 0], num_layers=y_layers)
+    geom.extrude(s, [0, 0, z], num_layers=z_layers)
+    points, cells, _, _, _ = pygmsh.generate_mesh(geom)
+
+    ref_vol = x * y * z
+    assert abs(compute_volume(points, cells) - ref_vol) < 1.0e-2 * ref_vol
+
+    # Each grid-cell from layered extrusion will result in 6 tetrahedrons.
+    ref_tetras = 6 * x_layers * y_layers * z_layers
+    assert len(cells["tetra"]) == ref_tetras
+
+    return points, cells
+
+
+if __name__ == "__main__":
+    import meshio
+
+    meshio.write_points_cells("cube.vtu", *test())


### PR DESCRIPTION
Adds the features asked for in #238 and #236, so far only for `built_in` geometries.

The `top` entity from a point extrusion is not yet usable, maybe a `PointBase` class needs to be added to get that right.

I successfully recreated my use cases with this (regular cubes and tubes), and added a simple test case in the same style.

If this goes well I will have a look at the Opencascade geometries as well, and might get around do some clean up.