### PR TITLE
relax check on suitable objects that can have a physical tag.

### DIFF
--- a/pygmsh/__about__.py
+++ b/pygmsh/__about__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 __author__ = u"Nico Schlömer"
 __author_email__ = "nico.schloemer@gmail.com"
 __copyright__ = u"Copyright (c) 2013-2019, {} <{}>".format(__author__, __author_email__)

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -181,7 +181,17 @@ class Geometry(object):
 
         for e in entities:
             assert isinstance(
-                e, (Point, Line, Surface, Volume, PlaneSurface, CircleArc)
+                e,
+                (
+                    Point,
+                    Line,
+                    CircleArc,
+                    Surface,
+                    PlaneSurface,
+                    SurfaceBase,
+                    Volume,
+                    VolumeBase,
+                ),
             ), "Can add physical groups only for Points, Lines, Surfaces, Volumes, not {}.".format(
                 type(e)
             )

--- a/test/test_physical.py
+++ b/test/test_physical.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import pygmsh
+
+
+def test(lcar=0.5):
+    geom = pygmsh.built_in.Geometry()
+    poly = geom.add_polygon(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]], lcar
+    )
+
+    top, volume, lat = geom.extrude(poly.surface, [0, 0, 2])
+
+    geom.add_physical(poly.surface, label="bottom")
+    geom.add_physical(top, label="top")
+    geom.add_physical(volume, label="volume")
+    geom.add_physical(lat, label="lat")
+    geom.add_physical(poly.lines[0], label="line")
+
+    mesh = pygmsh.generate_mesh(geom, geo_filename="physical.geo")
+    return mesh
+
+
+if __name__ == "__main__":
+    import meshio
+
+    meshio.write("physical.vtu", test())


### PR DESCRIPTION
The only requirement to add a physical tag is to have an id, so LineBase,
SurfaceBase and VolumeBase should qualify for it.
The test case is a pretty common use case in CFD, that fails without this
patch.