### PR TITLE
Implement ellipsoids for the OpenCascade engine

### DIFF
--- a/pygmsh/opencascade/ellipsoid.py
+++ b/pygmsh/opencascade/ellipsoid.py
@@ -1,0 +1,35 @@
+from .volume_base import VolumeBase
+
+
+class Ellipsoid(VolumeBase):
+    """
+    Creates an ellipsoid.
+
+    Parameters
+    ----------
+    center: array-like[3]
+        Center of the ball.
+    radii: array-like[3]
+        The radii of the ellipsoid along the semi-axes
+    char_length: float
+        If specified, sets the `Characteristic Length` property.
+    """
+
+    def __init__(self, center, radii, char_length=None):
+        super(Ellipsoid, self).__init__()
+
+        self.center = center
+        self.radii = radii
+        self.char_length = char_length
+
+        def as_str(point):
+            return ", ".join(str(x) for x in point)
+
+        self.code = "\n".join(
+            ["{} = newv;".format(self.id),
+             "Sphere({}) = {{ {}, 1.0 }};".format(self.id, as_str(center)),
+             "Dilate {{{{{}}}, {{{}}}}} {{ Volume{{{}}}; }}".format(as_str(center), as_str(radii), self.id),
+             ]
+            + self.char_length_code(char_length)
+        )
+        return

--- a/pygmsh/opencascade/ellipsoid.py
+++ b/pygmsh/opencascade/ellipsoid.py
@@ -8,7 +8,7 @@ class Ellipsoid(VolumeBase):
     Parameters
     ----------
     center: array-like[3]
-        Center of the ball.
+        Center of the ellipsoid.
     radii: array-like[3]
         The radii of the ellipsoid along the semi-axes
     char_length: float
@@ -26,10 +26,13 @@ class Ellipsoid(VolumeBase):
             return ", ".join(str(x) for x in point)
 
         self.code = "\n".join(
-            ["{} = newv;".format(self.id),
-             "Sphere({}) = {{ {}, 1.0 }};".format(self.id, as_str(center)),
-             "Dilate {{{{{}}}, {{{}}}}} {{ Volume{{{}}}; }}".format(as_str(center), as_str(radii), self.id),
-             ]
+            [
+                "{} = newv;".format(self.id),
+                "Sphere({}) = {{ {}, 1.0 }};".format(self.id, as_str(center)),
+                "Dilate {{{{{}}}, {{{}}}}} {{ Volume{{{}}}; }}".format(
+                    as_str(center), as_str(radii), self.id
+                ),
+            ]
             + self.char_length_code(char_length)
         )
         return

--- a/pygmsh/opencascade/ellipsoid.py
+++ b/pygmsh/opencascade/ellipsoid.py
@@ -1,7 +1,7 @@
-from .volume_base import VolumeBase
+from .ball import Ball
 
 
-class Ellipsoid(VolumeBase):
+class Ellipsoid(Ball):
     """
     Creates an ellipsoid.
 
@@ -11,24 +11,33 @@ class Ellipsoid(VolumeBase):
         Center of the ellipsoid.
     radii: array-like[3]
         The radii of the ellipsoid along the semi-axes
+    x0: float
+        If specified and `x0 > -1`, the ellipsoid is cut off at `x0*radius`
+        parallel to the y-z plane.
+    x1: float
+        If specified and `x1 < +1`, the ellipsoid is cut off at `x1*radius`
+        parallel to the y-z plane.
+    alpha: float
+        If specified and `alpha < 2*pi`, the points between `alpha` and
+        `2*pi` w.r.t. to the x-y plane are not part of the object.
     char_length: float
         If specified, sets the `Characteristic Length` property.
     """
 
-    def __init__(self, center, radii, char_length=None):
-        super(Ellipsoid, self).__init__()
-
+    def __init__(self, center, radii, char_length=None, **kwargs):
         self.center = center
         self.radii = radii
         self.char_length = char_length
+
+        # Instantiate the ball and later stretch it
+        Ball.__init__(self, center, 1.0, char_length=None, **kwargs)
 
         def as_str(point):
             return ", ".join(str(x) for x in point)
 
         self.code = "\n".join(
             [
-                "{} = newv;".format(self.id),
-                "Sphere({}) = {{ {}, 1.0 }};".format(self.id, as_str(center)),
+                self.code,
                 "Dilate {{{{{}}}, {{{}}}}} {{ Volume{{{}}}; }}".format(
                     as_str(center), as_str(radii), self.id
                 ),

--- a/pygmsh/opencascade/geometry.py
+++ b/pygmsh/opencascade/geometry.py
@@ -5,6 +5,7 @@ from .box import Box
 from .cone import Cone
 from .cylinder import Cylinder
 from .disk import Disk
+from .ellipsoid import Ellipsoid
 from .rectangle import Rectangle
 from .surface_base import SurfaceBase
 from .torus import Torus
@@ -65,6 +66,11 @@ class Geometry(bl.Geometry):
 
     def add_cylinder(self, *args, **kwargs):
         p = Cylinder(*args, **kwargs)
+        self._GMSH_CODE.append(p.code)
+        return p
+
+    def add_ellipsoid(self, *args, **kwargs):
+        p = Ellipsoid(*args, **kwargs)
         self._GMSH_CODE.append(p.code)
         return p
 

--- a/test/test_opencascade_ellipsoid.py
+++ b/test/test_opencascade_ellipsoid.py
@@ -1,0 +1,23 @@
+from math import pi
+import pytest
+
+import pygmsh
+from helpers import compute_volume
+
+
+@pytest.mark.skipif(pygmsh.get_gmsh_major_version() < 3, reason="requires Gmsh >= 3")
+def test():
+    geom = pygmsh.opencascade.Geometry()
+
+    geom.add_ellipsoid([1.0, 1.0, 1.0], [1.0, 2.0, 3.0], char_length=0.1)
+
+    ref = 8.0 * pi
+    mesh = pygmsh.generate_mesh(geom)
+    assert abs(compute_volume(mesh) - ref) < 1.0e-2 * ref
+    return mesh
+
+
+if __name__ == "__main__":
+    import meshio
+
+    meshio.write("opencascade_ellipsoid.vtu", test())


### PR DESCRIPTION
This adds basic capabilities to add ellipsoids with the OpenCascade
engine. The actual implementation idea is from this mailing list post
by Christophe Geuzaine:
http://onelab.info/pipermail/gmsh/2018/011986.html

I consider this commit to be a bugfix, because with the OpenCascade
implementation inheriting from the builtin one in pygmsh, adding ellipsoids
was so far supported in the interface, but it yielded weird geometries
that were not even convex.

If you are interested, I will happily add a cutting mechanism similar
to the OC-Ball one to the Ellipsoid class.