### PR TITLE
Added rotation to built-in geom

### DIFF
--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -1037,8 +1037,11 @@ class Geometry:
             "Rotate {{ {{{}}},  {{{}}}, {}  }} {{{}{{{}}}; }}".format(
                 ", ".join([str(ax) for ax in axis]),
                 ", ".join([str(p) for p in point]),
-                angle, d[input_entity.dimension],
-                input_entity.id,))
+                angle,
+                d[input_entity.dimension],
+                input_entity.id,
+            )
+        )
 
         return
 

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -1026,6 +1026,21 @@ class Geometry:
         )
         return
 
+    def rotate(self, input_entity, point, angle, axis):
+        """Translates input_entity itself by vector.
+
+        Changes the input object.
+        """
+        d = {1: "Line", 2: "Surface", 3: "Volume"}
+        self._GMSH_CODE.append(
+            "Rotate {{ {{{}}},  {{{}}}, {}  }} {{{}{{{}}}; }}".format(
+                ", ".join([str(ax) for ax in axis]),
+                ", ".join([str(p) for p in point]),
+                angle, d[input_entity.dimension],
+                input_entity.id,))
+
+        return
+
     def symmetry(self, input_entity, coefficients, duplicate=True):
         """Transforms all elementary entities symmetrically to a plane. The vector
         should contain four expressions giving the coefficients of the plane's equation.

--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -1027,7 +1027,8 @@ class Geometry:
         return
 
     def rotate(self, input_entity, point, angle, axis):
-        """Translates input_entity itself by vector.
+        """Rotate input_entity around a given point with a give angle.
+           Rotation axis has to be specified.
 
         Changes the input object.
         """

--- a/test/test_rotation.py
+++ b/test/test_rotation.py
@@ -2,12 +2,11 @@
 import numpy as np
 
 import pygmsh
-from helpers import compute_volume
 
 
-def test_translation2d():
+def test_rotation2d():
     """Rotation of a surface object."""
-    angle = np.pi/5
+    angle = np.pi / 5
 
     # Generate reference geometry
     geom = pygmsh.built_in.Geometry()
@@ -19,18 +18,18 @@ def test_translation2d():
     # Generate rotated geometry
     geom = pygmsh.built_in.Geometry()
     rect = geom.add_rectangle(0.0, 2.0, 0.0, 1.0, 0.0, 0.1)
-    geom.rotate(rect, [0,0,0], angle, [0,0,1])
+    geom.rotate(rect, [0, 0, 0], angle, [0, 0, 1])
     mesh = pygmsh.generate_mesh(geom, geo_filename="rot.geo")
     new_vertex_index = mesh.cells_dict["vertex"]
     new_vertex_index = new_vertex_index.reshape((new_vertex_index.shape[0],))
 
     # Generate rotation matrix and compare with rotated geometry
-    Rm = pygmsh.helpers.rotation_matrix([0,0,1], angle)
+    Rm = pygmsh.helpers.rotation_matrix([0, 0, 1], angle)
     for v, v_new in zip(vertex_index, new_vertex_index):
-        point = mesh_unrot.points[v,:]
+        point = mesh_unrot.points[v, :]
 
         rot_point = np.dot(Rm, point)
-        new_point = mesh.points[v,:]
+        new_point = mesh.points[v, :]
         assert np.allclose(rot_point, new_point)
 
     return

--- a/test/test_rotation.py
+++ b/test/test_rotation.py
@@ -1,0 +1,40 @@
+"""Test translation for all dimensions."""
+import numpy as np
+
+import pygmsh
+from helpers import compute_volume
+
+
+def test_translation2d():
+    """Rotation of a surface object."""
+    angle = np.pi/5
+
+    # Generate reference geometry
+    geom = pygmsh.built_in.Geometry()
+    rect = geom.add_rectangle(0.0, 2.0, 0.0, 1.0, 0.0, 0.1)
+    mesh_unrot = pygmsh.generate_mesh(geom, geo_filename="test.geo")
+    vertex_index = mesh_unrot.cells_dict["vertex"]
+    vertex_index = vertex_index.reshape((vertex_index.shape[0],))
+
+    # Generate rotated geometry
+    geom = pygmsh.built_in.Geometry()
+    rect = geom.add_rectangle(0.0, 2.0, 0.0, 1.0, 0.0, 0.1)
+    geom.rotate(rect, [0,0,0], angle, [0,0,1])
+    mesh = pygmsh.generate_mesh(geom, geo_filename="rot.geo")
+    new_vertex_index = mesh.cells_dict["vertex"]
+    new_vertex_index = new_vertex_index.reshape((new_vertex_index.shape[0],))
+
+    # Generate rotation matrix and compare with rotated geometry
+    Rm = pygmsh.helpers.rotation_matrix([0,0,1], angle)
+    for v, v_new in zip(vertex_index, new_vertex_index):
+        point = mesh_unrot.points[v,:]
+
+        rot_point = np.dot(Rm, point)
+        new_point = mesh.points[v,:]
+        assert np.allclose(rot_point, new_point)
+
+    return
+
+
+if __name__ == "__main__":
+    test_rotation2d()


### PR DESCRIPTION
Added missing geometry operation to built_in geometry.
Following example now works:
```
import pygmsh
import numpy as np

geom = pygmsh.built_in.Geometry()
rect = geom.add_rectangle(0.0, 2.0, 0.0, 1.0, 0.0, 0.1)
geom.rotate(rect, [0,0,0], np.pi/4, [0,0,1])

pygmsh.generate_mesh(geom, geo_filename="test_mesh.geo")
```