### PR TITLE
Added In Volume function to force volume mesh to include point(s)/curve(s)/surface(s)

### DIFF
--- a/pygmsh/built_in/geometry.py
+++ b/pygmsh/built_in/geometry.py
@@ -1063,8 +1063,21 @@ class Geometry:
         return
 
     def in_surface(self, input_entity, surface):
+        """Embed the point(s) or curve(s) in the given surface. The surface mesh
+        will conform to the mesh of the point(s) or curves(s).
+        """
         d = {0: "Point", 1: "Line"}
         entity = "{}{{{}}}".format(d[input_entity.dimension], input_entity.id)
 
         self._GMSH_CODE.append(f"{entity} In Surface{{{surface.id}}};")
+        return
+
+    def in_volume(self, input_entity, volume):
+        """Embed the point(s)/curve(s)/surface(s) in the given volume. The volume mesh
+        will conform to the mesh of the input entities.
+        """
+        d = {0: "Point", 1: "Line", 2: "Surface"}
+        entity = "{}{{{}}}".format(d[input_entity.dimension], input_entity.id)
+
+        self._GMSH_CODE.append(f"{entity} In Volume{{{volume.id}}};")
         return

--- a/test/test_in_volume.py
+++ b/test/test_in_volume.py
@@ -1,0 +1,35 @@
+from helpers import compute_volume
+
+import pygmsh
+
+
+def test():
+    geom = pygmsh.built_in.Geometry()
+
+    box = geom.add_box(-1, 2, -1, 2, -1, 1, lcar=0.5)
+    poly = geom.add_polygon(
+        [
+            [0, 0.3, 0],
+            [0, 1.1, 0],
+            [0.9, 1.1, 0],
+            [0.9, 0.3, 0],
+            [0.6, 0.7, 0],
+            [0.3, 0.7, 0],
+            [0.2, 0.4, 0],
+        ],
+        lcar=[0.2, 0.2, 0.2, 0.2, 0.03, 0.03, 0.01],
+    )
+    geom.in_volume(poly.lines[4], box.volume)
+    geom.in_volume(poly.points[6], box.volume)
+    geom.in_volume(poly.surface, box.volume)
+
+    ref = 18.0
+    mesh = pygmsh.generate_mesh(geom)
+    assert abs(compute_volume(mesh) - ref) < 1.0e-2 * ref
+    return mesh
+
+
+if __name__ == "__main__":
+    import meshio
+
+    meshio.write("test.vtk", test())


### PR DESCRIPTION
This PR is in response to the request in Issue #337.
It turns out the built-in geometry already had functionality for `In Surface` so I have only added `In Volume`, using a similar style and adding docstrings for both.  
I have also changed `is_list` to False for the boolean geometry function in the OpenCascade generator.  This was necessary in order to use `In Volume/Surface` when using an object that had been modified by a boolean operation.  This change did not affect the tests, however I am not sure if there are any other unintended effects of this as I do not know what the intended functionality of `is_list` was.