### PR TITLE
Broaden scope of method set_recombined_surfaces

### DIFF
--- a/pygmsh/common/geometry.py
+++ b/pygmsh/common/geometry.py
@@ -119,9 +119,7 @@ class CommonGeometry:
 
     def set_recombined_surfaces(self, surfaces):
         for i, surface in enumerate(surfaces):
-            assert isinstance(
-                surface, (PlaneSurface, Surface)
-            ), f"item {i} is not a surface"
+            assert surface.dim == 2, f"item {i} is not a surface"
         self._RECOMBINE_ENTITIES += [s.dim_tags[0] for s in surfaces]
 
     def extrude(


### PR DESCRIPTION
- Changed: assert entity's dimension instead of class. This allows `set_recombined_surfaces` to be used with OCC.