### PR TITLE
Adds arguments to `gmsh.initialize`

### DIFF
--- a/pygmsh/common/geometry.py
+++ b/pygmsh/common/geometry.py
@@ -24,9 +24,9 @@ class CommonGeometry:
     and occ.
     """
 
-    def __init__(self, env, argv):
+    def __init__(self, env, init_argv):
         self.env = env
-        self.argv = argv
+        self.init_argv = init_argv
         self._COMPOUND_ENTITIES = []
         self._RECOMBINE_ENTITIES = []
         self._EMBED_QUEUE = []
@@ -39,7 +39,9 @@ class CommonGeometry:
         self._OUTWARD_NORMALS = []
 
     def __enter__(self):
-        gmsh.initialize(self.argv)
+        if self.init_argv = None:
+            self.init_argv = []
+        gmsh.initialize(self.init_argv)
         gmsh.model.add("pygmsh model")
         return self
 

--- a/pygmsh/common/geometry.py
+++ b/pygmsh/common/geometry.py
@@ -39,7 +39,7 @@ class CommonGeometry:
         self._OUTWARD_NORMALS = []
 
     def __enter__(self):
-        if self.init_argv = None:
+        if self.init_argv is None:
             self.init_argv = []
         gmsh.initialize(self.init_argv)
         gmsh.model.add("pygmsh model")

--- a/pygmsh/common/geometry.py
+++ b/pygmsh/common/geometry.py
@@ -39,8 +39,8 @@ class CommonGeometry:
         self._PHYSICAL_QUEUE = []
         self._OUTWARD_NORMALS = []
 
-    def __enter__(self, argv=self.argv):
-        gmsh.initialize(argv)
+    def __enter__(self):
+        gmsh.initialize(self.argv)
         gmsh.model.add("pygmsh model")
         return self
 

--- a/pygmsh/common/geometry.py
+++ b/pygmsh/common/geometry.py
@@ -24,9 +24,9 @@ class CommonGeometry:
     and occ.
     """
 
-    def __init__(self, env, init_argv):
+    def __init__(self, env, argv):
         self.env = env
-        self.init_argv = init_argv
+        self.argv = argv
         self._COMPOUND_ENTITIES = []
         self._RECOMBINE_ENTITIES = []
         self._EMBED_QUEUE = []
@@ -39,9 +39,7 @@ class CommonGeometry:
         self._OUTWARD_NORMALS = []
 
     def __enter__(self):
-        if self.init_argv = None:
-            self.init_argv = []
-        gmsh.initialize(self.init_argv)
+        gmsh.initialize(self.argv)
         gmsh.model.add("pygmsh model")
         return self
 

--- a/pygmsh/common/geometry.py
+++ b/pygmsh/common/geometry.py
@@ -25,8 +25,9 @@ class CommonGeometry:
     and occ.
     """
 
-    def __init__(self, env):
+    def __init__(self, env, argv=[]):
         self.env = env
+        self.argv = argv
         self._COMPOUND_ENTITIES = []
         self._RECOMBINE_ENTITIES = []
         self._EMBED_QUEUE = []
@@ -38,8 +39,8 @@ class CommonGeometry:
         self._PHYSICAL_QUEUE = []
         self._OUTWARD_NORMALS = []
 
-    def __enter__(self):
-        gmsh.initialize()
+    def __enter__(self, argv=self.argv):
+        gmsh.initialize(argv)
         gmsh.model.add("pygmsh model")
         return self
 

--- a/pygmsh/common/geometry.py
+++ b/pygmsh/common/geometry.py
@@ -24,7 +24,7 @@ class CommonGeometry:
     and occ.
     """
 
-    def __init__(self, env, init_argv):
+    def __init__(self, env, init_argv=None):
         self.env = env
         self.init_argv = init_argv
         self._COMPOUND_ENTITIES = []

--- a/pygmsh/geo/geometry.py
+++ b/pygmsh/geo/geometry.py
@@ -33,8 +33,8 @@ class Circle:
 
 
 class Geometry(common.CommonGeometry):
-    def __init__(self, init_argv=None):
-        super().__init__(gmsh.model.geo, init_argv=init_argv)
+    def __init__(self, argv=[]):
+        super().__init__(gmsh.model.geo, argv=argv)
 
     def revolve(self, *args, **kwargs):
         if len(args) >= 4:

--- a/pygmsh/geo/geometry.py
+++ b/pygmsh/geo/geometry.py
@@ -33,8 +33,8 @@ class Circle:
 
 
 class Geometry(common.CommonGeometry):
-    def __init__(self, argv=[]):
-        super().__init__(gmsh.model.geo, argv=argv)
+    def __init__(self, init_argv=None):
+        super().__init__(gmsh.model.geo, init_argv=init_argv)
 
     def revolve(self, *args, **kwargs):
         if len(args) >= 4:

--- a/pygmsh/geo/geometry.py
+++ b/pygmsh/geo/geometry.py
@@ -33,8 +33,8 @@ class Circle:
 
 
 class Geometry(common.CommonGeometry):
-    def __init__(self):
-        super().__init__(gmsh.model.geo)
+    def __init__(self, argv=[]):
+        super().__init__(gmsh.model.geo, argv=argv)
 
     def revolve(self, *args, **kwargs):
         if len(args) >= 4:

--- a/pygmsh/occ/geometry.py
+++ b/pygmsh/occ/geometry.py
@@ -16,8 +16,8 @@ from .wedge import Wedge
 
 
 class Geometry(common.CommonGeometry):
-    def __init__(self, argv=[]):
-        super().__init__(gmsh.model.occ, argv=argv)
+    def __init__(self, init_argv=None):
+        super().__init__(gmsh.model.occ, init_argv=init_argv)
 
     def __exit__(self, *a):
         # TODO remove once gmsh 4.7.0 is out

--- a/pygmsh/occ/geometry.py
+++ b/pygmsh/occ/geometry.py
@@ -16,8 +16,8 @@ from .wedge import Wedge
 
 
 class Geometry(common.CommonGeometry):
-    def __init__(self):
-        super().__init__(gmsh.model.occ)
+    def __init__(self, argv=[]):
+        super().__init__(gmsh.model.occ, argv=argv)
 
     def __exit__(self, *a):
         # TODO remove once gmsh 4.7.0 is out

--- a/pygmsh/occ/geometry.py
+++ b/pygmsh/occ/geometry.py
@@ -16,8 +16,8 @@ from .wedge import Wedge
 
 
 class Geometry(common.CommonGeometry):
-    def __init__(self, init_argv=None):
-        super().__init__(gmsh.model.occ, init_argv=init_argv)
+    def __init__(self, argv=[]):
+        super().__init__(gmsh.model.occ, argv=argv)
 
     def __exit__(self, *a):
         # TODO remove once gmsh 4.7.0 is out


### PR DESCRIPTION
Fixes #434.

Allows the user to specify arguments to `gmsh.initialize`. At present `gmsh.initialize` interferes with operating system path on windows 10. See (https://gitlab.onelab.info/gmsh/gmsh/-/issues/1142). At present the only work around is to send the '-noenv` option by calling `gmsh.initialize(['-noenv'])`. This commit allows `pygmsh` users to specify that option when using `pygmsh.geo.Geometry()`.