### PR TITLE
check that physical tags can be written and read back again

### DIFF
--- a/tests/built_in/test_physical.py
+++ b/tests/built_in/test_physical.py
@@ -1,5 +1,6 @@
-import pygmsh
 import meshio
+
+import pygmsh
 
 
 def test(lcar=0.5):


### PR DESCRIPTION
Physical (and geometrical) tags are not written to file (independently of file format).
#423 fixes this by using `cell_data` instead of `cell_sets` since geometrical and physical data are required tags for each cell in gmsh, so there is no point in using cell sets for them.